### PR TITLE
Lazy-evaluate commit tag, message & comment

### DIFF
--- a/src/main/scala/ReleaseExtra.scala
+++ b/src/main/scala/ReleaseExtra.scala
@@ -107,8 +107,8 @@ object ReleaseStateTransformations {
     val status = (vcs(st).status !!) trim
 
     if (status.nonEmpty) {
-      val msg = st.extract.get(commitMessage)
-      vcs(st).commit(msg()) ! st.log
+      val msg = st.extract.runTask(commitMessage, st)._2
+      vcs(st).commit(msg) ! st.log
     } else {
       // nothing to commit. this happens if the version.sbt file hasn't changed.
     }
@@ -144,10 +144,10 @@ object ReleaseStateTransformations {
       }
     }
 
-    val tag = st.extract.get(tagName)
-    val comment = st.extract.get(tagComment)
-    val tagToUse = findTag(tag())
-    tagToUse.foreach(vcs(st).tag(_, comment(), force = true) !! st.log)
+    val tag = st.extract.runTask(tagName, st)._2
+    val comment = st.extract.runTask(tagComment, st)._2
+    val tagToUse = findTag(tag)
+    tagToUse.foreach(vcs(st).tag(_, comment, force = true) !! st.log)
 
 
     tagToUse map (t =>

--- a/src/main/scala/ReleasePlugin.scala
+++ b/src/main/scala/ReleasePlugin.scala
@@ -10,9 +10,9 @@ object ReleasePlugin extends Plugin {
     lazy val releaseProcess = SettingKey[Seq[ReleaseStep]]("release-process")
     lazy val releaseVersion = SettingKey[String => String]("release-release-version")
     lazy val nextVersion = SettingKey[String => String]("release-next-version")
-    lazy val tagName = SettingKey[() => String]("release-tag-name")
-    lazy val tagComment = SettingKey[() => String]("release-tag-comment")
-    lazy val commitMessage = SettingKey[() => String]("release-commit-message")
+    lazy val tagName = TaskKey[String]("release-tag-name")
+    lazy val tagComment = TaskKey[String]("release-tag-comment")
+    lazy val commitMessage = TaskKey[String]("release-commit-message")
 
     lazy val versionControlSystem = SettingKey[Option[Vcs]]("release-vcs")
 
@@ -54,9 +54,9 @@ object ReleasePlugin extends Plugin {
     releaseVersion := { ver => Version(ver).map(_.withoutQualifier.string).getOrElse(versionFormatError) },
     nextVersion := { ver => Version(ver).map(_.bumpMinor.asSnapshot.string).getOrElse(versionFormatError) },
 
-    tagName <<= (version in ThisBuild) (v => () => "v" + v),
-    tagComment <<= (version in ThisBuild) (v => () => "Releasing %s" format v),
-    commitMessage <<= (version in ThisBuild) (v => () => "Setting version to %s" format v),
+    tagName <<= (version in ThisBuild) map (v => "v" + v),
+    tagComment <<= (version in ThisBuild) map (v => "Releasing %s" format v),
+    commitMessage <<= (version in ThisBuild) map (v => "Setting version to %s" format v),
 
     versionControlSystem <<= (baseDirectory)(Vcs.detect(_)),
 


### PR DESCRIPTION
Computing their values can be a little bit expensive so this way only do
the computation if it's needed, not every time sbt is run.
