### PR TITLE
Recursively search parent directories for VCS marker directory

### DIFF
--- a/src/main/scala/Vcs.scala
+++ b/src/main/scala/Vcs.scala
@@ -47,8 +47,7 @@ trait GitLike extends Vcs {
   protected def cmd(args: Any*): ProcessBuilder = Process(exec +: args.map(_.toString))
 
   def isRepository(dir: File): Boolean =
-    if (new File(dir, markerDirectory).isDirectory) true
-    else Option(dir.getParentFile).map(isRepository(_)).getOrElse(false)
+    new File(dir, markerDirectory).isDirectory || Option(dir.getParentFile).exists(isRepository)
 
   def add(files: String*) = cmd(("add" +: files): _*)
 


### PR DESCRIPTION
When detecting the VCS, the plugin should recursively search the base directory's parent directories for the marker directory.

This functionality is required when a repository has the following layout:

```
some_project/
some_project/.git
some_project/some_module/
some_project/some_module/build.sbt
some_project/etc/
...
```

Otherwise, the release process will fail:

```
some_project/some_module $ sbt release 
...
[error] Aborting release. Working directory is not a repository of a recognized VCS.
[error] Use 'last' for the full log.
```
