### PR TITLE
Enable cross by default

### DIFF
--- a/src/main/scala/ReleasePlugin.scala
+++ b/src/main/scala/ReleasePlugin.scala
@@ -10,6 +10,7 @@ object ReleasePlugin extends Plugin {
     lazy val releaseProcess = SettingKey[Seq[ReleaseStep]]("release-process")
     lazy val releaseVersion = SettingKey[String => String]("release-release-version")
     lazy val nextVersion = SettingKey[String => String]("release-next-version")
+    lazy val autoCrossBuild = SettingKey[Boolean]("release-auto-cross-build")
     lazy val tagName = TaskKey[String]("release-tag-name")
     lazy val tagComment = TaskKey[String]("release-tag-comment")
     lazy val commitMessage = TaskKey[String]("release-commit-message")
@@ -30,7 +31,7 @@ object ReleasePlugin extends Plugin {
     val releaseCommand: Command = Command(releaseCommandKey)(_ => releaseParser) { (st, args) =>
       val extracted = Project.extract(st)
       val releaseParts = extracted.get(releaseProcess)
-      val crossEnabled = args.contains(CrossBuild)
+      val crossEnabled = extracted.get(autoCrossBuild) || args.contains(CrossBuild)
       val startState = st
         .put(useDefaults, args.contains(WithDefaults))
         .put(skipTests, args.contains(SkipTests))
@@ -60,6 +61,7 @@ object ReleasePlugin extends Plugin {
 
     releaseVersion := { ver => Version(ver).map(_.withoutQualifier.string).getOrElse(versionFormatError) },
     nextVersion := { ver => Version(ver).map(_.bumpMinor.asSnapshot.string).getOrElse(versionFormatError) },
+    autoCrossBuild := true,
 
     tagName <<= (version in ThisBuild) map (v => "v" + v),
     tagComment <<= (version in ThisBuild) map (v => "Releasing %s" format v),


### PR DESCRIPTION
The fact that you have to type "release cross" for projects that are
configured for cross building, but that "release cross" is the same as
"release" for projects that are not, caused us some problems. In
particular, people would forget to run "release cross".

So with this change, "release" is the same as "release cross". If you
wish to disable this feature for a particular project, you can include a
setting:

  sbtrelease.ReleasePlugin.ReleaseKeys.autoCrossBuild := false

...after pulling in sbtrelease.ReleasePlugin.releaseSettings.
