### PR TITLE
Fix for git complaining about version.sbt being out of repository

### DIFF
--- a/src/main/scala/ReleaseExtra.scala
+++ b/src/main/scala/ReleaseExtra.scala
@@ -121,7 +121,7 @@ object ReleaseStateTransformations {
   lazy val commitNextVersion = ReleaseStep(commitVersion)
   private[sbtrelease] def commitVersion = { st: State =>
     val file = st.extract.get(versionFile)
-    vcs(st).add(file.getAbsolutePath) !! st.log
+    vcs(st).add( file.getName ) !! st.log
     val status = (vcs(st).status !!) trim
 
     val newState = if (status.nonEmpty) {


### PR DESCRIPTION
Hello,

I had a problem with your plugin on a Windows box. Git could not add version.sbt to stage for commit, and I figured the reason was the full path and backslashes. I works now for me in a default way and I can make a release, though maybe something else got broken.

Thanks for the plugin,
Marcin
