### PR TITLE
Add parameter to allow ignore snapshot dependencies 

### DIFF
--- a/src/main/scala/ReleaseExtra.scala
+++ b/src/main/scala/ReleaseExtra.scala
@@ -24,10 +24,16 @@ object ReleaseStateTransformations {
     }
     if (!snapshotDeps.isEmpty) {
       val useDefaults = extractDefault(newSt, "n")
+      val executeCheck = !newSt.get(skipCheckSnapshotDependencies).getOrElse(false)
       st.log.warn("Snapshot dependencies detected:\n" + snapshotDeps.mkString("\n"))
-      useDefaults orElse SimpleReader.readLine("Do you want to continue (y/n)? [n] ") match {
-        case Yes() =>
-        case _ => sys.error("Aborting release due to snapshot dependencies.")
+      // do not execute check if skipCheck is defined
+      if (executeCheck) {
+        useDefaults orElse SimpleReader.readLine("Do you want to continue (y/n)? [n] ") match {
+          case Yes() =>
+          case _ => sys.error("Aborting release due to snapshot dependencies.")
+        }
+      } else {
+        st.log.warn("Snapshot dependencies detected but ignored")
       }
     }
     newSt
@@ -337,6 +343,5 @@ object Utilities {
     if (useDefs) Some(default)
     else None
   }
-
 }
 

--- a/src/main/scala/ReleasePlugin.scala
+++ b/src/main/scala/ReleasePlugin.scala
@@ -24,14 +24,16 @@ object ReleasePlugin extends Plugin {
     lazy val versions = AttributeKey[Versions]("release-versions")
     lazy val useDefaults = AttributeKey[Boolean]("release-use-defaults")
     lazy val skipTests = AttributeKey[Boolean]("release-skip-tests")
+    lazy val skipCheckSnapshotDependencies = AttributeKey[Boolean]("release-skip-check-snapshot-dependencies")
     lazy val cross = AttributeKey[Boolean]("release-cross")
 
     private lazy val releaseCommandKey = "release"
     private val WithDefaults = "with-defaults"
     private val SkipTests = "skip-tests"
+    private val SkipCheckSnapshotDependencies = "skip-check-snapshot-dependencies"
     private val CrossBuild = "cross"
     private val FailureCommand = "--failure--"
-    private val releaseParser = (Space ~> WithDefaults | Space ~> SkipTests | Space ~> CrossBuild).*
+    private val releaseParser = (Space ~> WithDefaults | Space ~> SkipTests | Space ~> SkipCheckSnapshotDependencies | Space ~> CrossBuild).*
 
     val releaseCommand: Command = Command(releaseCommandKey)(_ => releaseParser) { (st, args) =>
       val extracted = Project.extract(st)
@@ -41,6 +43,7 @@ object ReleasePlugin extends Plugin {
         .copy(onFailure = Some(FailureCommand))
         .put(useDefaults, args.contains(WithDefaults))
         .put(skipTests, args.contains(SkipTests))
+        .put(skipCheckSnapshotDependencies, args.contains(SkipCheckSnapshotDependencies))
         .put(cross, crossEnabled)
 
       val initialChecks = releaseParts.map(_.check)


### PR DESCRIPTION
Hi, 
here's a pull request allowing, when you're doing an automatic release, to ignore snapshot dependencies if needed.

Regards, 

Olivier.
