### PR TITLE
Fixed cwd for the VCS cmd

### DIFF
--- a/src/main/scala/Vcs.scala
+++ b/src/main/scala/Vcs.scala
@@ -44,7 +44,7 @@ object Vcs {
 trait GitLike extends Vcs {
   private lazy val exec = executableName(commandName)
 
-  def cmd(args: Any*): ProcessBuilder = Process(exec +: args.map(_.toString))
+  def cmd(args: Any*): ProcessBuilder = Process(exec +: args.map(_.toString), baseDir)
 
   def add(files: String*) = cmd(("add" +: files): _*)
 


### PR DESCRIPTION
VCS `cmd` should run from the `baseDir` of this VCS
- because then you relativize paths of added/commited files to `baseDir` ([here](https://github.com/sbt/sbt-release/blob/master/src/main/scala/ReleaseExtra.scala#L125-L127) for example)
- if you clone other git repo inside of the current one and try to use it with `Git.mkVcs(file("another-repo"))` it doesn't work (runs from the current repo's `baseDir`)

So I just added the cwd parameter to the [`Process`](http://www.scala-lang.org/api/2.10.3/index.html#scala.sys.process.Process$) constructor.
