### PR TITLE
Include a trailing newline character in version.sbt

### DIFF
--- a/src/main/scala/ReleaseExtra.scala
+++ b/src/main/scala/ReleaseExtra.scala
@@ -81,7 +81,7 @@ object ReleaseStateTransformations {
 
     st.log.info("Setting version to '%s'." format selected)
 
-    val versionString = "version in ThisBuild := \"%s\"" format selected
+    val versionString = "version in ThisBuild := \"%s\"\n" format selected
     writeVersion(st, versionString)
 
     reapply(Seq(


### PR DESCRIPTION
It's just a good general practice (and avoids potential problems with other tools)
