### PR TITLE
Git: use HEAD to determine current hash

### DIFF
--- a/src/main/scala/Vcs.scala
+++ b/src/main/scala/Vcs.scala
@@ -113,7 +113,7 @@ class Git(val baseDir: File) extends Vcs with GitLike {
 
   def currentBranch =  (cmd("symbolic-ref", "HEAD") !!).trim.stripPrefix("refs/heads/")
 
-  def currentHash = revParse(currentBranch)
+  def currentHash = revParse("HEAD")
 
   private def revParse(name: String) = (cmd("rev-parse", name) !!) trim
 


### PR DESCRIPTION
This is more robust in a detached HEAD situation.

(I'm using the VCS detection in sbt-typelevel.)
