### PR TITLE
Ensure that task failure is propogated.

### DIFF
--- a/src/main/scala/ReleasePlugin.scala
+++ b/src/main/scala/ReleasePlugin.scala
@@ -46,7 +46,7 @@ object ReleasePlugin extends Plugin {
 
       def filterFailure(f: State => State)(s: State): State = {
         s.remainingCommands match {
-          case FailureCommand :: tail => s
+          case FailureCommand :: tail => s.fail
           case _ => f(s)
         }
       }


### PR DESCRIPTION
This invokes state.fail when the FailureCommand has been added to
state.remainingCommands (because onFailure was called). This ensures
that sbt returns proper exit codes when an intermediate task in the
release process fails.

Refs #79 (I was seeing something similar with a failed test).

I don't understand the sbt State model super well, so I found this solution by trial and error. It's possible there's another (better) one. I'm also a bit stumped as to why the scripted test introduced in b21f9e92016f07b49625c8a8d70d266c27127923 succeeds if the failure isn't propagated to update exit codes.

In any case, I've done some simple testing of this change to verify that it fixes the build and keeps exit-codes 0 for successful releases, too. 
