### PR TITLE
Use publish-signed

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,12 @@ If you want to customize the versioning, keep the following in mind:
     tagComment    <<= (version in ThisBuild) map (v => "Releasing %s" format v),
     commitMessage <<= (version in ThisBuild) map (v => "Setting version to %s" format v)
 
+### Publishing signed releases
+SBT is able to publish signed releases using the [sbt-pgp plugin](https://github.com/sbt/sbt-pgp).
+
+After setting that up for your project, you can then tell *sbt-release* to use it by setting the `publishArtifactsAction` key:
+
+    publishArtifactsAction := PgpKeys.publishSigned.value
 
 ## Customizing the release process
 ### Not all releases are created equal

--- a/src/main/scala/ReleaseExtra.scala
+++ b/src/main/scala/ReleaseExtra.scala
@@ -225,7 +225,7 @@ object ReleaseStateTransformations {
   }
 
   lazy val publishArtifacts = ReleaseStep(
-    action = publishArtifactsAction,
+    action = runPublishArtifactsAction,
     check = st => {
       // getPublishTo fails if no publish repository is set up.
       val ex = st.extract
@@ -235,10 +235,10 @@ object ReleaseStateTransformations {
     },
     enableCrossBuild = true
   )
-  private[sbtrelease] lazy val publishArtifactsAction = { st: State =>
+  private[sbtrelease] lazy val runPublishArtifactsAction = { st: State =>
     val extracted = st.extract
     val ref = extracted.get(thisProjectRef)
-    extracted.runAggregated(publish in Global in ref, st)
+    extracted.runAggregated(publishArtifactsAction in Global in ref, st)
   }
 
   private def readVersion(ver: String, prompt: String, useDef: Boolean): String = {

--- a/src/main/scala/ReleasePlugin.scala
+++ b/src/main/scala/ReleasePlugin.scala
@@ -19,6 +19,7 @@ object ReleasePlugin extends Plugin {
     lazy val useGlobalVersion = SettingKey[Boolean]("release-use-global-version")
 
     lazy val versionControlSystem = SettingKey[Option[Vcs]]("release-vcs")
+    lazy val publishArtifactsAction = TaskKey[Unit]("release-publish-artifacts-action", "The action that should be performed to publish artifacts")
 
     lazy val versions = AttributeKey[Versions]("release-versions")
     lazy val useDefaults = AttributeKey[Boolean]("release-use-defaults")
@@ -94,6 +95,8 @@ object ReleasePlugin extends Plugin {
     versionControlSystem <<= (baseDirectory)(Vcs.detect(_)),
 
     versionFile := file("version.sbt"),
+
+    publishArtifactsAction <<= publish.map(identity),
 
     releaseProcess := Seq[ReleaseStep](
       checkSnapshotDependencies,


### PR DESCRIPTION
From what I understand, the sbt pgp plugin as of v0.8 does not sign artifacts with publish. Instead you should use publish-signed if available.
