### PR TITLE
Git: only push released tag

### DIFF
--- a/src/main/scala/Vcs.scala
+++ b/src/main/scala/Vcs.scala
@@ -136,7 +136,12 @@ class Git(val baseDir: File) extends Vcs with GitLike {
     cmd("push", trackingRemote, "%s:%s" format (localBranch, trackingBranch))
   }
 
-  private def pushTags = cmd("push", "--tags", trackingRemote)
+  private def pushTags = {
+    val lastTag = (cmd("for-each-ref", "--count=1", "--sort=-taggerdate", "--format", "%(tag)", "refs/tags") !!).
+      linesIterator.next()
+    cmd("push", trackingRemote, lastTag)
+  }
+
 }
 
 object Subversion extends VcsCompanion {


### PR DESCRIPTION
When using git and performing a release all tags will be pushed and not only the released tag. This produces an error that tags already exists. This pull request will change that behavior so only the released tag is pushed.
