### PR TITLE
sbt-plugin-releases is hosted on bintray now

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Add the following lines to `./project/plugins.sbt`. See the section [Using Plugi
     // This resolver declaration is added by default in SBT 0.12.x
     resolvers += Resolver.url(
       "sbt-plugin-releases",
-      new URL("http://scalasbt.artifactoryonline.com/scalasbt/sbt-plugin-releases/")
+      new URL("https://dl.bintray.com/sbt/sbt-plugin-releases/")
     )(Resolver.ivyStylePatterns)
 
     addSbtPlugin("com.github.gseitz" % "sbt-release" % "0.8.5")


### PR DESCRIPTION
@jsuereth, am I right that the readme was referring to an outdated URL?