### PR TITLE
allow release and next versions to be specified on the command line

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,7 +220,7 @@ I highly recommend to make yourself familiar with the [State API](http://www.sca
 
 ### Can we finally customize that release process, please?
 
-Yes, and as a start, let's take a look at the [default definition](https://github.com/sbt/sbt-release/blob/master/src/main/scala/ReleasePlugin.scala#L49) of `releaseProcess`:
+Yes, and as a start, let's take a look at the [default definition](https://github.com/sbt/sbt-release/blob/v1.0.0/src/main/scala/ReleasePlugin.scala#L177) of `releaseProcess`:
 
 #### The default release process
 

--- a/build.sbt
+++ b/build.sbt
@@ -10,6 +10,9 @@ sbtPlugin := true
 publishMavenStyle := false
 scalacOptions += "-deprecation"
 
+libraryDependencies ++= Seq("org.specs2" %% "specs2-core" % "3.6" % "test")
+resolvers += "scalaz-bintray" at "http://dl.bintray.com/scalaz/releases"
+
 // Scripted
 scriptedSettings
 scriptedLaunchOpts <<= (scriptedLaunchOpts, version) { case (s,v) => s ++

--- a/src/sbt-test/sbt-release/command-line-version-numbers/build.sbt
+++ b/src/sbt-test/sbt-release/command-line-version-numbers/build.sbt
@@ -1,0 +1,30 @@
+import ReleaseTransformations._
+import sbt.complete.DefaultParsers._
+
+publishTo := Some(Resolver.file("file",  new File( "." )) )
+
+releaseProcess := Seq[ReleaseStep](
+  checkSnapshotDependencies,              // : ReleaseStep
+  inquireVersions,                        // : ReleaseStep
+  runTest,                                // : ReleaseStep
+  setReleaseVersion,                      // : ReleaseStep
+  //commitReleaseVersion,                   // : ReleaseStep, performs the initial git checks
+  //tagRelease,                             // : ReleaseStep
+  publishArtifacts,                       // : ReleaseStep, checks whether `publishTo` is properly set up
+  setNextVersion//,                         // : ReleaseStep
+  //commitNextVersion//,                      // : ReleaseStep
+  //pushChanges                             // : ReleaseStep, also checks that an upstream branch is properly configured
+)
+scalaVersion := "2.10.3"
+
+
+val checkContentsOfVersionSbt = inputKey[Unit]("Check that the contents of version.sbt is as expected")
+val parser = Space ~> StringBasic
+
+checkContentsOfVersionSbt := {
+  val expected = parser.parsed
+      val versionFile = ((baseDirectory).value) / "version.sbt"
+      assert(IO.read(versionFile).contains(expected), s"does not contains ${expected} in ${versionFile}")
+}
+
+

--- a/src/sbt-test/sbt-release/command-line-version-numbers/build.sbt
+++ b/src/sbt-test/sbt-release/command-line-version-numbers/build.sbt
@@ -4,16 +4,12 @@ import sbt.complete.DefaultParsers._
 publishTo := Some(Resolver.file("file",  new File( "." )) )
 
 releaseProcess := Seq[ReleaseStep](
-  checkSnapshotDependencies,              // : ReleaseStep
-  inquireVersions,                        // : ReleaseStep
-  runTest,                                // : ReleaseStep
-  setReleaseVersion,                      // : ReleaseStep
-  //commitReleaseVersion,                   // : ReleaseStep, performs the initial git checks
-  //tagRelease,                             // : ReleaseStep
-  publishArtifacts,                       // : ReleaseStep, checks whether `publishTo` is properly set up
-  setNextVersion//,                         // : ReleaseStep
-  //commitNextVersion//,                      // : ReleaseStep
-  //pushChanges                             // : ReleaseStep, also checks that an upstream branch is properly configured
+  checkSnapshotDependencies,
+  inquireVersions,
+  runTest,
+  setReleaseVersion,
+  publishArtifacts,
+  setNextVersion
 )
 scalaVersion := "2.10.3"
 

--- a/src/sbt-test/sbt-release/command-line-version-numbers/project/build.properties
+++ b/src/sbt-test/sbt-release/command-line-version-numbers/project/build.properties
@@ -1,0 +1,1 @@
+# not setting the sbt version explicitly will use the version for the current sbt cross-build

--- a/src/sbt-test/sbt-release/command-line-version-numbers/project/build.sbt
+++ b/src/sbt-test/sbt-release/command-line-version-numbers/project/build.sbt
@@ -1,0 +1,9 @@
+{
+  val pluginVersion = System.getProperty("plugin.version")
+  if(pluginVersion == null)
+    throw new RuntimeException("""|The system property 'plugin.version' is not defined.
+                                  |Specify this property using the scriptedLaunchOpts -D.""".stripMargin)
+  else {
+    addSbtPlugin("com.github.gseitz" % "sbt-release" % pluginVersion)
+  }
+}

--- a/src/sbt-test/sbt-release/command-line-version-numbers/src/main/scala/Hello.scala
+++ b/src/sbt-test/sbt-release/command-line-version-numbers/src/main/scala/Hello.scala
@@ -1,0 +1,3 @@
+object Main extends App {
+  println("hello")
+}

--- a/src/sbt-test/sbt-release/command-line-version-numbers/test
+++ b/src/sbt-test/sbt-release/command-line-version-numbers/test
@@ -1,0 +1,3 @@
+> 'release release-version 36.14.3 next-version 36.14.4-SNAPSHOT'
+$ exists target/scala-2.10/command-line-version-numbers_2.10-36.14.3.jar
+> checkContentsOfVersionSbt 36.14.4-SNAPSHOT

--- a/src/sbt-test/sbt-release/command-line-version-numbers/version.sbt
+++ b/src/sbt-test/sbt-release/command-line-version-numbers/version.sbt
@@ -1,0 +1,1 @@
+version in ThisBuild := "36.14.4-SNAPSHOT"

--- a/src/test/scala/VersionSpec.scala
+++ b/src/test/scala/VersionSpec.scala
@@ -1,0 +1,42 @@
+package sbtrelease
+
+import org.specs2.mutable.Specification
+
+object VersionSpec extends Specification {
+
+  def version(v: String) = Version(v) match {
+    case Some(parsed) => parsed
+    case None => sys.error("Can't parse version " + v)
+  }
+
+  "Version bumping" should {
+    def bump(v: String) = version(v).bump.string
+
+    "bump the major version if there's only a major version" in {
+      bump("1") must_== "2"
+    }
+    "bump the minor version if there's only a minor version" in {
+      bump("1.2") must_== "1.3"
+    }
+    "bump the bugfix version if there's only a bugfix version" in {
+      bump("1.2.3") must_== "1.2.4"
+    }
+    "drop the qualifier if it's a pre release" in {
+      bump("1-rc1") must_== "1"
+      bump("1.2-rc1") must_== "1.2"
+      bump("1.2.3-rc1") must_== "1.2.3"
+
+      bump("1-rc") must_== "1"
+      bump("1-RC1") must_== "1"
+      bump("1-M1") must_== "1"
+      bump("1-rc-1") must_== "1"
+      bump("1-beta") must_== "1"
+      bump("1-beta-1") must_== "1"
+      bump("1-alpha") must_== "1"
+    }
+    "not drop the qualifier if it's not a pre release" in {
+      bump("1.2.3-Final") must_== "1.2.4-Final"
+    }
+  }
+
+}

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "1.0.1-SNAPSHOT"
+version in ThisBuild := "1.0.2-SNAPSHOT"


### PR DESCRIPTION
This pull request would resolve this issue: https://github.com/sbt/sbt-release/issues/96

I found the parsing library to be a bit strange, resulting in args being a Seq[Serializable], the elements are  either ((String, List[String]),String) or String.

In 'readVersion', I have defaulted to using the command line version, if absent, then use the default version, if absent, then prompt for versions.