### PR TITLE
Avoid git push output on stderr

### DIFF
--- a/src/main/scala/ReleaseExtra.scala
+++ b/src/main/scala/ReleaseExtra.scala
@@ -232,7 +232,6 @@ object ReleaseStateTransformations {
     if (vc.hasUpstream) {
       defaultChoice orElse SimpleReader.readLine("Push changes to the remote repository (y/n)? [y] ") match {
         case Yes() | Some("") =>
-          if (vc.isInstanceOf[Git]) st.log.info("git push sends its console output to standard error, which will cause the next few lines to be marked as [error].")
           vcs(st).pushChanges !! st.log
         case _ => st.log.warn("Remember to push the changes yourself!")
       }

--- a/src/main/scala/Vcs.scala
+++ b/src/main/scala/Vcs.scala
@@ -133,10 +133,10 @@ class Git(val baseDir: File) extends Vcs with GitLike {
 
   private def pushCurrentBranch = {
     val localBranch = currentBranch
-    cmd("push", trackingRemote, "%s:%s" format (localBranch, trackingBranch))
+    cmd("push", "--porcelain", trackingRemote, "%s:%s" format (localBranch, trackingBranch))
   }
 
-  private def pushTags = cmd("push", "--tags", trackingRemote)
+  private def pushTags = cmd("push", "--porcelain", "--tags", trackingRemote)
 }
 
 object Subversion extends VcsCompanion {


### PR DESCRIPTION
Hello, 

I was annoyed with git push output to stderr putting red error in release plugin output log. I see the log info message and issue https://github.com/sbt/sbt-release/issues/20 about it but I though it would be cleaner to avoid it completely.

I used git's push --porcelain switch to keep some useful info on the output (rev sha1 being pushed), but --quiet could have done it too.

Do you think this could be merged or is there another improvment we can add to this ?

Best regards,