### PR TITLE
Allow sub-version numbers (e.g., X.Y.Z.N)

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,8 @@ This sbt plugin provides a customizable release process that you can add to your
 ## Requirements
  * sbt 0.13.5+
  * The version of the project should follow the semantic versioning scheme on [semver.org](http://www.semver.org) with the following additions:
-   * The minor and bugfix part of the version are optional.
+   * The minor and bugfix (and beyond) part of the version are optional.
+   * There is no limit to the number of subverions you may have.
    * The appendix after the bugfix part must be alphanumeric (`[0-9a-zA-Z]`) but may also contain dash characters `-`.
    * These are all valid version numbers:
      * 1.2.3
@@ -15,6 +16,8 @@ This sbt plugin provides a customizable release process that you can add to your
      * 1.2
      * 1
      * 1-BETA17
+     * 1.2.3.4.5
+     * 1.2.3.4.5-SNAPSHOT
  * A [publish repository](http://www.scala-sbt.org/release/docs/Publishing.html) configured. (Required only for the default release process. See further below for release process customizations.)
  * git [optional]
 
@@ -95,7 +98,8 @@ As of version 0.8, *sbt-release* comes with four strategies for computing the ne
  * `Major`: always bumps the *major* part of the version
  * `Minor`: always bumps the *minor* part of the version
  * `Bugfix`: always bumps the *bugfix* part of the version
- * `Next`: bumps the last version part (e.g. `0.17` -> `0.18`, `0.11.7` -> `0.11.8`)
+ * `Nano`: always bumps the *nano* part of the version
+ * `Next`: bumps the last version part (e.g. `0.17` -> `0.18`, `0.11.7` -> `0.11.8`, `3.22.3.4.91` -> `3.22.3.4.92`)
 
 Example:
 

--- a/src/main/scala/Version.scala
+++ b/src/main/scala/Version.scala
@@ -33,12 +33,12 @@ object Version {
   }
 }
 
-case class Version(major: Int, subVersions: Seq[Int], qualifier: Option[String]) {
+case class Version(major: Int, subversions: Seq[Int], qualifier: Option[String]) {
   def bump = {
     val maybeBumpedPrerelease = qualifier.collect {
       case Version.PreReleaseQualifierR() => withoutQualifier
     }
-    def maybeBumpedLastSubversion = bumpSubversionOpt(subVersions.length-1)
+    def maybeBumpedLastSubversion = bumpSubversionOpt(subversions.length-1)
     def bumpedMajor = copy(major = major + 1)
 
     maybeBumpedPrerelease
@@ -46,19 +46,19 @@ case class Version(major: Int, subVersions: Seq[Int], qualifier: Option[String])
       .getOrElse(bumpedMajor)
   }
 
-  def bumpMajor  = copy(major = major + 1, subVersions = Seq.fill(subVersions.length)(0))
-  def bumpMinor  = bumpSubversion(0)
-  def bumpBugfix = bumpSubversion(1)
-  def bumpNano   = bumpSubversion(2)
+  def bumpMajor  = copy(major = major + 1, subversions = Seq.fill(subversions.length)(0))
+  def bumpMinor  = maybeBumpSubversion(0)
+  def bumpBugfix = maybeBumpSubversion(1)
+  def bumpNano   = maybeBumpSubversion(2)
 
-  def bumpSubversion(idx: Int) = bumpSubversionOpt(idx) getOrElse this
+  def maybeBumpSubversion(idx: Int) = bumpSubversionOpt(idx) getOrElse this
 
   private def bumpSubversionOpt(idx: Int) = {
-    val bumped = subVersions.drop(idx)
+    val bumped = subversions.drop(idx)
     val reset = bumped.drop(1).length
     bumped.headOption map { head =>
       val patch = (head+1) +: Seq.fill(reset)(0)
-      copy(subVersions = subVersions.patch(idx, patch, patch.length))
+      copy(subversions = subversions.patch(idx, patch, patch.length))
     }
   }
 
@@ -67,7 +67,7 @@ case class Version(major: Int, subVersions: Seq[Int], qualifier: Option[String])
   def withoutQualifier = copy(qualifier = None)
   def asSnapshot = copy(qualifier = Some("-SNAPSHOT"))
 
-  def string = "" + major + mkString(subVersions) + qualifier.getOrElse("")
+  def string = "" + major + mkString(subversions) + qualifier.getOrElse("")
 
   private def mkString(parts: Seq[Int]) = parts.map("."+_).mkString
 }

--- a/src/main/scala/Version.scala
+++ b/src/main/scala/Version.scala
@@ -11,47 +11,63 @@ object Version {
     object Major extends Bump { def bump = _.bumpMajor }
     object Minor extends Bump { def bump = _.bumpMinor }
     object Bugfix extends Bump { def bump = _.bumpBugfix }
+    object Nano extends Bump { def bump = _.bumpNano }
     object Next extends Bump { def bump = _.bump }
 
     val default = Next
   }
 
-  val VersionR = """([0-9]+)(?:(?:\.([0-9]+))?(?:\.([0-9]+))?)?([\-0-9a-zA-Z]*)?""".r
+  val VersionR = """([0-9]+)((?:\.[0-9]+)+)?([\-0-9a-zA-Z]*)?""".r
   val PreReleaseQualifierR = """[\.-](?i:rc|m|alpha|beta)[\.-]?[0-9]*""".r
 
   def apply(s: String): Option[Version] = {
     allCatch opt {
-      val VersionR(maj, min, mic, qual) = s
-      Version(maj.toInt, Option(min).map(_.toInt), Option(mic).map(_.toInt), Option(qual).filterNot(_.isEmpty))
+      val VersionR(maj, subs, qual) = s
+      // parse the subversions (if any) to a Seq[Int]
+      val subSeq: Seq[Int] = Option(subs) map { str =>
+        // split on . and remove empty strings
+        str.split('.').filterNot(_.trim.isEmpty).map(_.toInt).toSeq
+      } getOrElse Nil
+      Version(maj.toInt, subSeq, Option(qual).filterNot(_.isEmpty))
     }
   }
 }
 
-case class Version(major: Int, minor: Option[Int], bugfix: Option[Int], qualifier: Option[String]) {
+case class Version(major: Int, subVersions: Seq[Int], qualifier: Option[String]) {
   def bump = {
     val maybeBumpedPrerelease = qualifier.collect {
       case Version.PreReleaseQualifierR() => withoutQualifier
     }
-    def maybeBumpedBugfix = bugfix.map(m => copy(bugfix = Some(m + 1)))
-    def maybeBumpedMinor = minor.map(m => copy(minor = Some(m + 1)))
+    def maybeBumpedLastSubversion = bumpSubversionOpt(subVersions.length-1)
     def bumpedMajor = copy(major = major + 1)
 
     maybeBumpedPrerelease
-      .orElse(maybeBumpedBugfix)
-      .orElse(maybeBumpedMinor)
+      .orElse(maybeBumpedLastSubversion)
       .getOrElse(bumpedMajor)
   }
 
-  def bumpMajor = copy(major = major + 1, minor = minor.map(_ => 0), bugfix = bugfix.map(_ => 0))
-  def bumpMinor = copy(minor = minor.map(_ + 1), bugfix = bugfix.map(_ => 0))
-  def bumpBugfix = copy(bugfix = bugfix.map(_ + 1))
+  def bumpMajor  = copy(major = major + 1, subVersions = Seq.fill(subVersions.length)(0))
+  def bumpMinor  = bumpSubversion(0)
+  def bumpBugfix = bumpSubversion(1)
+  def bumpNano   = bumpSubversion(2)
+
+  def bumpSubversion(idx: Int) = bumpSubversionOpt(idx) getOrElse this
+
+  private def bumpSubversionOpt(idx: Int) = {
+    val bumped = subVersions.drop(idx)
+    val reset = bumped.drop(1).length
+    bumped.headOption map { head =>
+      val patch = (head+1) +: Seq.fill(reset)(0)
+      copy(subVersions = subVersions.patch(idx, patch, patch.length))
+    }
+  }
 
   def bump(bumpType: Version.Bump): Version = bumpType.bump(this)
 
   def withoutQualifier = copy(qualifier = None)
   def asSnapshot = copy(qualifier = Some("-SNAPSHOT"))
 
-  def string = "" + major + get(minor) + get(bugfix) + qualifier.getOrElse("")
+  def string = "" + major + mkString(subVersions) + qualifier.getOrElse("")
 
-  private def get(part: Option[Int]) = part.map("." + _).getOrElse("")
+  private def mkString(parts: Seq[Int]) = parts.map("."+_).mkString
 }

--- a/src/test/scala/VersionSpec.scala
+++ b/src/test/scala/VersionSpec.scala
@@ -74,7 +74,7 @@ object VersionSpec extends Specification {
   }
 
   "Subversion bumping" should {
-    def bumpSubversion(v: String)(i: Int) = version(v).bumpSubversion(i).string
+    def bumpSubversion(v: String)(i: Int) = version(v).maybeBumpSubversion(i).string
 
     "bump the subversion" in {
       bumpSubversion("1.2")(0) must_== "1.3"

--- a/src/test/scala/VersionSpec.scala
+++ b/src/test/scala/VersionSpec.scala
@@ -21,6 +21,9 @@ object VersionSpec extends Specification {
     "bump the bugfix version if there's only a bugfix version" in {
       bump("1.2.3") must_== "1.2.4"
     }
+    "bump the nano version if there's only a nano version" in {
+      bump("1.2.3.4") must_== "1.2.3.5"
+    }
     "drop the qualifier if it's a pre release" in {
       bump("1-rc1") must_== "1"
       bump("1.2-rc1") must_== "1.2"
@@ -36,6 +39,54 @@ object VersionSpec extends Specification {
     }
     "not drop the qualifier if it's not a pre release" in {
       bump("1.2.3-Final") must_== "1.2.4-Final"
+    }
+    "not drop the post-nano qualifier if it's not a pre release" in {
+      bump("1.2.3.4-Final") must_== "1.2.3.5-Final"
+    }
+  }
+
+  "Major Version bumping" should {
+    def bumpMajor(v: String) = version(v).bumpMajor.string
+
+    "bump the major version and reset other versions" in {
+      bumpMajor("1.2.3.4.5") must_== "2.0.0.0.0"
+    }
+    "not drop the qualifier" in {
+      bumpMajor("1.2.3.4.5-alpha") must_== "2.0.0.0.0-alpha"
+    }
+  }
+
+  "Minor Version bumping" should {
+    def bumpMinor(v: String) = version(v).bumpMinor.string
+
+    "bump the minor version" in {
+      bumpMinor("1.2") must_== "1.3"
+    }
+    "bump the minor version and reset other subversions" in {
+      bumpMinor("1.2.3.4.5") must_== "1.3.0.0.0"
+    }
+    "not bump the major version when no minor version" in {
+      bumpMinor("1") must_== "1"
+    }
+    "not drop the qualifier" in {
+      bumpMinor("1.2.3.4.5-alpha") must_== "1.3.0.0.0-alpha"
+    }
+  }
+
+  "Subversion bumping" should {
+    def bumpSubversion(v: String)(i: Int) = version(v).bumpSubversion(i).string
+
+    "bump the subversion" in {
+      bumpSubversion("1.2")(0) must_== "1.3"
+    }
+    "bump the subversion and reset lower subversions" in {
+      bumpSubversion("1.2.3.4.5")(0) must_== "1.3.0.0.0"
+    }
+    "not change anything with an invalid subversion index" in {
+      bumpSubversion("1.2-beta")(1) must_== "1.2-beta"
+    }
+    "not drop the qualifier" in {
+      bumpSubversion("1.2.3.4.5-alpha")(2) must_== "1.2.3.5.0-alpha"
     }
   }
 


### PR DESCRIPTION
These changes allow for a Major version with any number of sub-version numbers.  Explicit support for Major, Minor, Release, and Nano.  The default version bump is always for the lowest subversion.