### PR TITLE
Use IO.writeLines to write version.sbt with a trailing EOL

### DIFF
--- a/src/main/scala/ReleaseExtra.scala
+++ b/src/main/scala/ReleaseExtra.scala
@@ -116,7 +116,7 @@ object ReleaseStateTransformations {
 
   private def writeVersion(st: State, versionString: String) {
     val file = st.extract.get(releaseVersionFile)
-    IO.write(file, versionString)
+    IO.writeLines(file, Seq(versionString))
   }
 
   private[sbtrelease] lazy val initialVcsChecks = { st: State =>


### PR DESCRIPTION
Before:

```
[msa@Michaels-MacBook-Pro event-ingester]$ cat version.sbt 
version in ThisBuild := "1.6.14-SNAPSHOT"[msa@Michaels-MacBook-Pro event-ingester]$ 
```

:cry:

After:

```
[msa@Michaels-MacBook-Pro event-ingester]$ cat version.sbt 
version in ThisBuild := "1.6.14-SNAPSHOT"
[msa@Michaels-MacBook-Pro event-ingester]$ 
```

:smile: