### PR TITLE
Support the new git worktree feature

### DIFF
--- a/src/main/scala/Vcs.scala
+++ b/src/main/scala/Vcs.scala
@@ -54,8 +54,9 @@ trait GitLike extends Vcs {
 trait VcsCompanion {
   protected val markerDirectory: String
 
+  // Using the new git worktree feature the dir is now a file, so checking for exists should be enough
   def isRepository(dir: File): Option[File] =
-    if (new File(dir, markerDirectory).isDirectory) Some(dir)
+    if (new File(dir, markerDirectory).exists) Some(dir)
     else Option(dir.getParentFile).flatMap(isRepository)
 
   def mkVcs(baseDir: File): Vcs


### PR DESCRIPTION
When using `git worktree add ...` to have multiple working directories against a single clone, the `.git` directory is not a directory but a file that tells git where to look for the real repository. Changed the code to only look if the directory/file exists instead of it only being a directory.

This should be benign for `hg` and `svn` as well, since you don't have a `.hg` or `.svn` files in a normal repo.