### PR TITLE
Add dot to list of allowed characters for qualifier in version pattern

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ This sbt plugin provides a customizable release process that you can add to your
      * 1.2.3
      * 1.2.3-SNAPSHOT
      * 1.2beta1
+     * 1.2-beta.1
      * 1.2
      * 1
      * 1-BETA17

--- a/src/main/scala/Version.scala
+++ b/src/main/scala/Version.scala
@@ -17,7 +17,7 @@ object Version {
     val default = Next
   }
 
-  val VersionR = """([0-9]+)((?:\.[0-9]+)+)?([\-0-9a-zA-Z]*)?""".r
+  val VersionR = """([0-9]+)((?:\.[0-9]+)+)?([\.\-0-9a-zA-Z]*)?""".r
   val PreReleaseQualifierR = """[\.-](?i:rc|m|alpha|beta)[\.-]?[0-9]*""".r
 
   def apply(s: String): Option[Version] = {

--- a/src/test/scala/VersionSpec.scala
+++ b/src/test/scala/VersionSpec.scala
@@ -33,8 +33,10 @@ object VersionSpec extends Specification {
       bump("1-RC1") must_== "1"
       bump("1-M1") must_== "1"
       bump("1-rc-1") must_== "1"
+      bump("1-rc.1") must_== "1"
       bump("1-beta") must_== "1"
       bump("1-beta-1") must_== "1"
+      bump("1-beta.1") must_== "1"
       bump("1-alpha") must_== "1"
     }
     "not drop the qualifier if it's not a pre release" in {


### PR DESCRIPTION
Although `PreReleaseQualifierR` allows pre-releases which include a dot character it can't be specified due to restrictions in `VersionR`. This patch modifies the regular expression of the qualifier part in `VersionR` and adds a dot to the list of allowed characters which enables pre-releases like `1.0.0-rc.1`.