### PR TITLE
ReleasePlugin should be disabled when JvmPlugin is disabled

### DIFF
--- a/src/main/scala/ReleasePlugin.scala
+++ b/src/main/scala/ReleasePlugin.scala
@@ -3,6 +3,7 @@ package sbtrelease
 import java.io.Serializable
 
 import sbt._
+import sbt.plugins._
 import Keys._
 import _root_.sbt.complete.DefaultParsers._
 import sbt.complete.DefaultParsers._
@@ -175,6 +176,8 @@ object ReleasePlugin extends AutoPlugin {
   import ReleaseStateTransformations._
 
   override def trigger = allRequirements
+  
+  override def requires = JvmPlugin
 
   override def projectSettings = Seq[Setting[_]](
     releaseSnapshotDependencies := {


### PR DESCRIPTION
Because ReleasePlugin requires settings like managedClasspath defined in JvmPlugin
