### PR TITLE
Add whenRelease function to disable ReleaseStep while on snapshot

### DIFF
--- a/src/main/scala/ReleaseExtra.scala
+++ b/src/main/scala/ReleaseExtra.scala
@@ -52,6 +52,8 @@ object ReleaseStateTransformations {
     newSt
   }
 
+  def whenRelease(releaseStep: ReleaseStep): ReleaseStep =
+    releaseStep.copy(state => if (Project.extract(state).get(isSnapshot)) state else releaseStep.action(state))
 
   lazy val inquireVersions: ReleaseStep = { st: State =>
 


### PR DESCRIPTION
I found it useful to manage a single list of release steps, while enabling some of them only on non-snapshot versions, like

``` scala
releaseProcess := Seq[ReleaseStep](
  checkSnapshotDependencies,
  runClean,
  runTest,
  whenRelease(commitReleaseVersion),
  whenRelease(tagRelease),
  publishArtifacts,
  whenRelease(pushChanges)
)
```

On snapshot version steps marked by whenRelease are not executed.

Maybe it could be useful enough for a broader audience to be included into the upstream.
