### PR TITLE
Fix #173: Remove private from `runTaskAggregated`

### DIFF
--- a/src/main/scala/ReleaseExtra.scala
+++ b/src/main/scala/ReleaseExtra.scala
@@ -13,7 +13,7 @@ import ReleaseKeys._
 object ReleaseStateTransformations {
   import Utilities._
 
-  private def runTaskAggregated[T](taskKey: TaskKey[T], state: State): (State, Result[Seq[KeyValue[T]]]) = {
+  def runTaskAggregated[T](taskKey: TaskKey[T], state: State): (State, Result[Seq[KeyValue[T]]]) = {
     import EvaluateTask._
     val extra = DummyTaskMap(Nil)
     val extracted = state.extract


### PR DESCRIPTION
Fix #173.

Sbt exposes `runTask` and `runAggregated` publicly. `runTaskAggregated`
should behave the same way, since people may want to extend/modify
release steps such as `checkSnapshotDependencies`.
