### PR TITLE
Make version control keys Tasks instead of Settings, close #189

### DIFF
--- a/src/main/scala/ReleaseExtra.scala
+++ b/src/main/scala/ReleaseExtra.scala
@@ -60,13 +60,13 @@ object ReleaseStateTransformations {
     val useDefs = st.get(useDefaults).getOrElse(false)
     val currentV = extracted.get(version)
 
-    val releaseFunc = extracted.get(releaseVersion)
+    val releaseFunc = extracted.runTask(releaseVersion, st)._2
     val suggestedReleaseV = releaseFunc(currentV)
 
     //flatten the Option[Option[String]] as the get returns an Option, and the value inside is an Option
     val releaseV = readVersion(suggestedReleaseV, "Release version [%s] : ", useDefs, st.get(commandLineReleaseVersion).flatten)
 
-    val nextFunc = extracted.get(releaseNextVersion)
+    val nextFunc = extracted.runTask(releaseNextVersion, st)._2
     val suggestedNextV = nextFunc(releaseV)
     //flatten the Option[Option[String]] as the get returns an Option, and the value inside is an Option
     val nextV = readVersion(suggestedNextV, "Next version [%s] : ", useDefs, st.get(commandLineNextVersion).flatten)

--- a/src/main/scala/ReleasePlugin.scala
+++ b/src/main/scala/ReleasePlugin.scala
@@ -13,9 +13,9 @@ object ReleasePlugin extends AutoPlugin {
   object autoImport {
     val releaseSnapshotDependencies = taskKey[Seq[ModuleID]]("Calculate the snapshot dependencies for a build")
     val releaseProcess = settingKey[Seq[ReleaseStep]]("The release process")
-    val releaseVersion = settingKey[String => String]("The release version")
-    val releaseNextVersion = settingKey[String => String]("The next release version")
-    val releaseVersionBump = settingKey[Version.Bump]("How the version should be incremented")
+    val releaseVersion = taskKey[String => String]("The release version")
+    val releaseNextVersion = taskKey[String => String]("The next release version")
+    val releaseVersionBump = taskKey[Version.Bump]("How the version should be incremented")
     val releaseTagName = taskKey[String]("The name of the tag")
     val releaseTagComment = taskKey[String]("The comment to use when tagging")
     val releaseCommitMessage = taskKey[String]("The commit message to use when tagging")


### PR DESCRIPTION
Making those settings tasks gives a more dynamic control of what should be the next versions.