### PR TITLE
Make commit & tag messages build-level settings

### DIFF
--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.8
+sbt.version=0.13.15

--- a/src/main/scala/ReleasePlugin.scala
+++ b/src/main/scala/ReleasePlugin.scala
@@ -201,6 +201,14 @@ object ReleasePlugin extends AutoPlugin {
 
   override def trigger = allRequirements
 
+  override val buildSettings: Seq[Setting[_]] = Seq(
+    releaseUseGlobalVersion := true,
+
+    releaseTagName := s"v${if (releaseUseGlobalVersion.value) (version in ThisBuild).value else version.value}",
+    releaseTagComment := s"Releasing ${if (releaseUseGlobalVersion.value) (version in ThisBuild).value else version.value}",
+    releaseCommitMessage := s"Setting version to ${if (releaseUseGlobalVersion.value) (version in ThisBuild).value else version.value}"
+  )
+
   override def projectSettings = Seq[Setting[_]](
     releaseSnapshotDependencies := {
       val moduleIds = (managedClasspath in Runtime).value.flatMap(_.get(moduleID.key))
@@ -213,12 +221,7 @@ object ReleasePlugin extends AutoPlugin {
     releaseNextVersion := {
       ver => Version(ver).map(_.bump(releaseVersionBump.value).asSnapshot.string).getOrElse(versionFormatError)
     },
-    releaseUseGlobalVersion := true,
     releaseCrossBuild := false,
-
-    releaseTagName := s"v${if (releaseUseGlobalVersion.value) (version in ThisBuild).value else version.value}",
-    releaseTagComment := s"Releasing ${if (releaseUseGlobalVersion.value) (version in ThisBuild).value else version.value}",
-    releaseCommitMessage := s"Setting version to ${if (releaseUseGlobalVersion.value) (version in ThisBuild).value else version.value}",
 
     releaseVcs := Vcs.detect(baseDirectory.value),
     releaseVcsSign := false,

--- a/src/sbt-test/sbt-release/doge-integration/project/build.properties
+++ b/src/sbt-test/sbt-release/doge-integration/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.12
+# not setting the sbt version explicitly will use the version for the current sbt cross-build


### PR DESCRIPTION
I end up doing this in every project where I use sbt-release:

```scala
lazy val releaseSettings = Seq(
  // Commit messages should use imperative mood
  releaseTagComment := s"Release ${(version in ThisBuild).value}",
  releaseCommitMessage := s"Set version to ${(version in ThisBuild).value}"
)
```

Then I need to add `settings(releaseSettings)` to every applicable module of multi-project builds or include them in some common settings collection. That has become tedious, so here I am. I would like for these to be able to delegate to `ThisBuild` so I can just do this once, perhaps even in an umbrella plugin for team standards:

```scala
releaseTagComment in ThisBuild := s"Release ${(version in ThisBuild).value}"
releaseCommitMessage in ThisBuild := s"Set version to ${(version in ThisBuild).value}"
```

Could more settings sensibly move to `buildSettings`? Quite possibly, I didn't think about it very hard, these are ones that initially were of interest to me but I'm open to suggestions.

Also the scripted suite seems to have some issue in my environment, if Travis fails for this PR or you'd like a new test for this change I'll dig further into what's not kosher on my machine. Apologies for being in a bit of a rush.

(By the way, if you're open to changing the default messages to present tense, imperative mood as many style guides call for in accordance with the Git project's own convention, I'd be happy to change it. But I suspect people could have automation scripting in their pipeline reliant on the existing default messages, so it might be considered a compatibility breakage).