### PR TITLE
Cross build for sbt 1.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ jdk: oraclejdk8
 
 env:
   matrix:
-    - SBT_CMD=";test;publishLocal;scripted"
+    - SBT_CMD=";++2.10.6;^^0.13.16-RC1;test;publishLocal;scripted"
     - SBT_CMD=";++2.12.2;^^1.0.0-RC2;test;publishLocal;scripted"
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: scala
 
-jdk:
-  - oraclejdk8
+jdk: oraclejdk8
 
 env:
   matrix:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,8 @@
 language: scala
 
+jdk:
+  - oraclejdk8
+
 env:
   matrix:
     - SBT_CMD=";test;publishLocal;scripted"

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: scala
 env:
   matrix:
     - SELECT_VERSION="++2.10.6 ^^0.13.16-M1"
-    - SELECT_VERSION="++2.12.2 ^^1.0.0-M6"
+    - SELECT_VERSION="++2.12.2 ^^1.0.0-RC2"
 
 script:
  - git config --global user.email "example@example.com"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,17 @@
 language: scala
+
+env:
+  matrix:
+    - SELECT_VERSION="++2.10.6 ^^0.13.16-M1"
+    - SELECT_VERSION="++2.12.2 ^^1.0.0-M6"
+
 script:
  - git config --global user.email "example@example.com"
  - git config --global user.name "example"
  - echo '[ui]' > "$HOME/.hgrc"
  - echo 'username = example <example@example.com>' >> "$HOME/.hgrc"
- - sbt test
- - sbt publishLocal
- - sbt scripted
+ - sbt "$SELECT_VERSION test"
+ - sbt "$SELECT VERSION publishLocal"
+ - sbt "$SELECT VERSION scripted"
+
 sudo: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,4 +14,13 @@ script:
  - sbt "$SELECT VERSION publishLocal"
  - sbt "$SELECT VERSION scripted"
 
+cache:
+  directories:
+    - $HOME/.ivy2/cache
+    - $HOME/.sbt/boot/
+before_cache:
+  # Tricks to avoid unnecessary cache updates
+  - find $HOME/.ivy2 -name "ivydata-*.properties" -delete
+  - find $HOME/.sbt -name "*.lock" -delete
+
 sudo: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,17 +2,15 @@ language: scala
 
 env:
   matrix:
-    - SELECT_VERSION="++2.10.6 ^^0.13.16-M1"
-    - SELECT_VERSION="++2.12.2 ^^1.0.0-RC2"
+    - SBT_CMD=";test;publishLocal;scripted"
+    - SBT_CMD=";++2.12.2;^^1.0.0-RC2;test;publishLocal;scripted"
 
 script:
  - git config --global user.email "example@example.com"
  - git config --global user.name "example"
  - echo '[ui]' > "$HOME/.hgrc"
  - echo 'username = example <example@example.com>' >> "$HOME/.hgrc"
- - sbt "$SELECT_VERSION test"
- - sbt "$SELECT VERSION publishLocal"
- - sbt "$SELECT VERSION scripted"
+ - sbt "$SBT_CMD"
 
 cache:
   directories:

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ This sbt plugin provides a customizable release process that you can add to your
 
 **Notice:** This README contains information for the latest release. Please refer to the documents for a specific version by looking up the respective [tag](https://github.com/sbt/sbt-release/tags).
 
-[![Build Status](https://travis-ci.org/sbt/sbt-release.svg?branch=master)](https://travis-ci.org/leonardehrenfried/sbt-release)
+[![Build Status](https://travis-ci.org/sbt/sbt-release.svg?branch=master)](https://travis-ci.org/sbt/sbt-release)
 
 ## Requirements
  * sbt 0.13.5+

--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@ This sbt plugin provides a customizable release process that you can add to your
 
 **Notice:** This README contains information for the latest release. Please refer to the documents for a specific version by looking up the respective [tag](https://github.com/sbt/sbt-release/tags).
 
+[![Build Status](https://travis-ci.org/leonardehrenfried/sbt-release.svg?branch=master)](https://travis-ci.org/leonardehrenfried/sbt-release)
+
 ## Requirements
  * sbt 0.13.5+
  * The version of the project should follow the semantic versioning scheme on [semver.org](http://www.semver.org) with the following additions:

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ This sbt plugin provides a customizable release process that you can add to your
 
 **Notice:** This README contains information for the latest release. Please refer to the documents for a specific version by looking up the respective [tag](https://github.com/sbt/sbt-release/tags).
 
-[![Build Status](https://travis-ci.org/leonardehrenfried/sbt-release.svg?branch=master)](https://travis-ci.org/leonardehrenfried/sbt-release)
+[![Build Status](https://travis-ci.org/sbt/sbt-release.svg?branch=master)](https://travis-ci.org/leonardehrenfried/sbt-release)
 
 ## Requirements
  * sbt 0.13.5+

--- a/build.sbt
+++ b/build.sbt
@@ -16,25 +16,6 @@ resolvers += "scalaz-bintray" at "http://dl.bintray.com/scalaz/releases"
 
 // Scripted
 
-// workaround from https://github.com/sbt/sbt/issues/3325
-scriptedSettings.filterNot(_.key.key.label == libraryDependencies.key.label)
-
-
-libraryDependencies ++= {
-  CrossVersion.binarySbtVersion(scriptedSbt.value) match {
-    case "0.13" =>
-      Seq(
-        "org.scala-sbt" % "scripted-sbt" % scriptedSbt.value % scriptedConf.toString,
-        "org.scala-sbt" % "sbt-launch" % scriptedSbt.value % scriptedLaunchConf.toString
-      )
-    case _ =>
-      Seq(
-        "org.scala-sbt" %% "scripted-sbt" % scriptedSbt.value % scriptedConf.toString,
-        "org.scala-sbt" % "sbt-launch" % scriptedSbt.value % scriptedLaunchConf.toString
-      )
-  }
-}
-
 scriptedLaunchOpts := {
   Seq("-Xmx1024M", "-XX:MaxPermSize=256M", "-Dplugin.version=" + version.value)
 }

--- a/build.sbt
+++ b/build.sbt
@@ -6,7 +6,7 @@ name := "sbt-release"
 homepage := Some(url("https://github.com/sbt/sbt-release"))
 licenses := Seq("Apache-2.0" -> url("http://www.apache.org/licenses/LICENSE-2.0"))
 
-crossSbtVersions := Vector("0.13.15", "1.0.0-RC2")
+crossSbtVersions := Vector("0.13.16-RC1", "1.0.0-RC2")
 sbtPlugin := true
 publishMavenStyle := false
 scalacOptions += "-deprecation"

--- a/build.sbt
+++ b/build.sbt
@@ -6,7 +6,7 @@ name := "sbt-release"
 homepage := Some(url("https://github.com/sbt/sbt-release"))
 licenses := Seq("Apache-2.0" -> url("http://www.apache.org/licenses/LICENSE-2.0"))
 
-crossSbtVersions := Vector("0.13.15", "1.0.0-M6")
+crossSbtVersions := Vector("0.13.15", "1.0.0-RC2")
 sbtPlugin := true
 publishMavenStyle := false
 scalacOptions += "-deprecation"

--- a/build.sbt
+++ b/build.sbt
@@ -16,7 +16,7 @@ libraryDependencies ++= Seq("org.specs2" %% "specs2-core" % "3.9.4" % "test")
 // Scripted
 
 scriptedSettings
-scriptedLaunchOpts := Seq("-Xmx1024M", "-XX:MaxPermSize=256M", "-Dplugin.version=" + version.value)
+scriptedLaunchOpts := Seq("-Xmx1024M", "-XX:MaxPermSize=256M", "-Dplugin.version=" + version.value, "-Dsbt.version=" + sbtVersion.value)
 
 scriptedBufferLog := false
 

--- a/build.sbt
+++ b/build.sbt
@@ -12,7 +12,6 @@ publishMavenStyle := false
 scalacOptions += "-deprecation"
 
 libraryDependencies ++= Seq("org.specs2" %% "specs2-core" % "3.9.4" % "test")
-resolvers += "scalaz-bintray" at "http://dl.bintray.com/scalaz/releases"
 
 // Scripted
 

--- a/build.sbt
+++ b/build.sbt
@@ -6,18 +6,39 @@ name := "sbt-release"
 homepage := Some(url("https://github.com/sbt/sbt-release"))
 licenses := Seq("Apache-2.0" -> url("http://www.apache.org/licenses/LICENSE-2.0"))
 
+crossSbtVersions := Vector("0.13.15", "1.0.0-M6")
 sbtPlugin := true
 publishMavenStyle := false
 scalacOptions += "-deprecation"
 
-libraryDependencies ++= Seq("org.specs2" %% "specs2-core" % "3.6" % "test")
+libraryDependencies ++= Seq("org.specs2" %% "specs2-core" % "3.9.4" % "test")
 resolvers += "scalaz-bintray" at "http://dl.bintray.com/scalaz/releases"
 
 // Scripted
-scriptedSettings
-scriptedLaunchOpts <<= (scriptedLaunchOpts, version) { case (s,v) => s ++
-  Seq("-Xmx1024M", "-XX:MaxPermSize=256M", "-Dplugin.version=" + v)
+
+// workaround from https://github.com/sbt/sbt/issues/3325
+scriptedSettings.filterNot(_.key.key.label == libraryDependencies.key.label)
+
+
+libraryDependencies ++= {
+  CrossVersion.binarySbtVersion(scriptedSbt.value) match {
+    case "0.13" =>
+      Seq(
+        "org.scala-sbt" % "scripted-sbt" % scriptedSbt.value % scriptedConf.toString,
+        "org.scala-sbt" % "sbt-launch" % scriptedSbt.value % scriptedLaunchConf.toString
+      )
+    case _ =>
+      Seq(
+        "org.scala-sbt" %% "scripted-sbt" % scriptedSbt.value % scriptedConf.toString,
+        "org.scala-sbt" % "sbt-launch" % scriptedSbt.value % scriptedLaunchConf.toString
+      )
+  }
 }
+
+scriptedLaunchOpts := {
+  Seq("-Xmx1024M", "-XX:MaxPermSize=256M", "-Dplugin.version=" + version.value)
+}
+
 scriptedBufferLog := false
 
 // Bintray

--- a/build.sbt
+++ b/build.sbt
@@ -16,7 +16,7 @@ libraryDependencies ++= Seq("org.specs2" %% "specs2-core" % "3.9.4" % "test")
 // Scripted
 
 scriptedSettings
-scriptedLaunchOpts := Seq("-Xmx1024M", "-XX:MaxPermSize=256M", "-Dplugin.version=" + version.value, "-Dsbt.version=" + sbtVersion.value)
+scriptedLaunchOpts := Seq("-Xmx1024M", "-XX:MaxPermSize=256M", "-Dplugin.version=" + version.value, "-Dsbt.version=" + (sbtVersion in pluginCrossBuild).value)
 
 scriptedBufferLog := false
 

--- a/build.sbt
+++ b/build.sbt
@@ -16,6 +16,7 @@ resolvers += "scalaz-bintray" at "http://dl.bintray.com/scalaz/releases"
 
 // Scripted
 
+scriptedSettings
 scriptedLaunchOpts := Seq("-Xmx1024M", "-XX:MaxPermSize=256M", "-Dplugin.version=" + version.value)
 
 scriptedBufferLog := false

--- a/build.sbt
+++ b/build.sbt
@@ -16,9 +16,7 @@ resolvers += "scalaz-bintray" at "http://dl.bintray.com/scalaz/releases"
 
 // Scripted
 
-scriptedLaunchOpts := {
-  scriptedLaunchOpts.value ++ Seq("-Xmx1024M", "-XX:MaxPermSize=256M", "-Dplugin.version=" + version.value)
-}
+scriptedLaunchOpts := Seq("-Xmx1024M", "-XX:MaxPermSize=256M", "-Dplugin.version=" + version.value)
 
 scriptedBufferLog := false
 

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.16-M1
+sbt.version=0.13.16-RC1

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.8
+sbt.version=0.13.16-M1

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -3,5 +3,4 @@ libraryDependencies += "org.scala-sbt" % "scripted-plugin" % sbtVersion.value
 addSbtPlugin("me.lessis" % "bintray-sbt" % "0.3.0")
 addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.0.0")
 
-// This project is its own plugin :)
-unmanagedSourceDirectories in Compile += baseDirectory.value.getParentFile / "src" / "main" / "scala"
+addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.5")

--- a/src/main/scala-sbt-0.13/Compat.scala
+++ b/src/main/scala-sbt-0.13/Compat.scala
@@ -58,7 +58,7 @@ object Compat {
       case _ => false
     }
 
-  def crossVersions(st: State): Seq[String] = Cross.crossVersions(st)
+  val crossVersions = Cross.crossVersions _
 
   // type aliases
   type StructureIndex = sbt.StructureIndex

--- a/src/main/scala-sbt-0.13/Compat.scala
+++ b/src/main/scala-sbt-0.13/Compat.scala
@@ -12,6 +12,7 @@ import sbt.Package.ManifestAttributes
 import annotation.tailrec
 import ReleasePlugin.autoImport._
 import ReleaseKeys._
+import sbt.Def.ScopedKey
 
 object Compat {
 
@@ -50,6 +51,12 @@ object Compat {
   }
 
   val FailureCommand = "--failure--"
+
+  def excludeKeys(keys: Set[AttributeKey[_]]): Setting[_] => Boolean =
+    _.key match {
+      case ScopedKey(Scope(_, Global, Global, _), key) if keys.contains(key) => true
+      case _ => false
+    }
 
   // type aliases
   type StructureIndex = sbt.StructureIndex

--- a/src/main/scala-sbt-0.13/Compat.scala
+++ b/src/main/scala-sbt-0.13/Compat.scala
@@ -60,6 +60,8 @@ object Compat {
 
   val crossVersions = Cross.crossVersions _
 
+  type Command = String
+
   // type aliases
   type StructureIndex = sbt.StructureIndex
   type BuildStructure = sbt.BuildStructure

--- a/src/main/scala-sbt-0.13/Compat.scala
+++ b/src/main/scala-sbt-0.13/Compat.scala
@@ -58,6 +58,8 @@ object Compat {
       case _ => false
     }
 
+  def crossVersions(st: State): Seq[String] = Cross.crossVersions(st)
+
   // type aliases
   type StructureIndex = sbt.StructureIndex
   type BuildStructure = sbt.BuildStructure

--- a/src/main/scala-sbt-0.13/Compat.scala
+++ b/src/main/scala-sbt-0.13/Compat.scala
@@ -12,6 +12,7 @@ import sbt.Package.ManifestAttributes
 import annotation.tailrec
 import ReleasePlugin.autoImport._
 import ReleaseKeys._
+import sbt.{Load => iLoad}
 
 object Compat {
 
@@ -36,4 +37,6 @@ object Compat {
     }
     (newS, result)
   }
+
+  val Load = iLoad
 }

--- a/src/main/scala-sbt-0.13/Compat.scala
+++ b/src/main/scala-sbt-0.13/Compat.scala
@@ -1,7 +1,7 @@
 package sbtrelease
 
 import sbt.std.Transform.DummyTaskMap
-import sbt.{EvaluateTask, Result, ScopeMask, State, TaskKey, Act, Aggregation}
+import sbt.{EvaluateTask, Result, ScopeMask, State, TaskKey, Act, Aggregation, Scope, Reference, Select}
 import sbt.Aggregation.KeyValue
 import sbt.Keys._
 import sbt._
@@ -12,7 +12,6 @@ import sbt.Package.ManifestAttributes
 import annotation.tailrec
 import ReleasePlugin.autoImport._
 import ReleaseKeys._
-import sbt.{Load => iLoad}
 
 object Compat {
 
@@ -38,5 +37,16 @@ object Compat {
     (newS, result)
   }
 
-  val Load = iLoad
+  def projectScope(project: Reference): Scope = Scope(Select(project), Global, Global, Global)
+
+  type StructureIndex = sbt.StructureIndex
+  type BuildStructure = sbt.BuildStructure
+  val BuildStreams = sbt.BuildStreams
+  type BuildUtil[Proj] = sbt.BuildUtil[Proj]
+  val BuildUtil = sbt.BuildUtil
+  val Index = sbt.Index
+  type KeyIndex = sbt.KeyIndex
+  val KeyIndex = sbt.KeyIndex
+  type LoadedBuildUnit = sbt.LoadedBuildUnit
+
 }

--- a/src/main/scala-sbt-0.13/Compat.scala
+++ b/src/main/scala-sbt-0.13/Compat.scala
@@ -49,6 +49,8 @@ object Compat {
     st
   }
 
+  val FailureCommand = "--failure--"
+
   // type aliases
   type StructureIndex = sbt.StructureIndex
   type BuildStructure = sbt.BuildStructure

--- a/src/main/scala-sbt-0.13/Compat.scala
+++ b/src/main/scala-sbt-0.13/Compat.scala
@@ -15,9 +15,10 @@ import ReleaseKeys._
 
 object Compat {
 
+  import Utilities._
+
   def runTaskAggregated[T](taskKey: TaskKey[T], state: State): (State, Result[Seq[KeyValue[T]]]) = {
     import EvaluateTask._
-    import Utilities._
 
     val extra = DummyTaskMap(Nil)
     val extracted = state.extract
@@ -39,6 +40,16 @@ object Compat {
 
   def projectScope(project: Reference): Scope = Scope(Select(project), Global, Global, Global)
 
+  // checking if publishTo is configured
+  def checkPublishTo(st: State ): State = {
+    // getPublishTo fails if no publish repository is set up.
+    val ex = st.extract
+    val ref = ex.get(thisProjectRef)
+    Classpaths.getPublishTo(ex.get(publishTo in Global in ref))
+    st
+  }
+
+  // type aliases
   type StructureIndex = sbt.StructureIndex
   type BuildStructure = sbt.BuildStructure
   val BuildStreams = sbt.BuildStreams

--- a/src/main/scala-sbt-0.13/Compat.scala
+++ b/src/main/scala-sbt-0.13/Compat.scala
@@ -1,0 +1,39 @@
+package sbtrelease
+
+import sbt.std.Transform.DummyTaskMap
+import sbt.{EvaluateTask, Result, ScopeMask, State, TaskKey, Act, Aggregation}
+import sbt.Aggregation.KeyValue
+import sbt.Keys._
+import sbt._
+import sbt.Aggregation.KeyValue
+import sbt.std.Transform.DummyTaskMap
+import sbt.Keys._
+import sbt.Package.ManifestAttributes
+import annotation.tailrec
+import ReleasePlugin.autoImport._
+import ReleaseKeys._
+
+object Compat {
+
+  def runTaskAggregated[T](taskKey: TaskKey[T], state: State): (State, Result[Seq[KeyValue[T]]]) = {
+    import EvaluateTask._
+    import Utilities._
+
+    val extra = DummyTaskMap(Nil)
+    val extracted = state.extract
+    val config = extractedTaskConfig(extracted, extracted.structure, state)
+
+    val rkey = Utilities.resolve(taskKey.scopedKey, extracted)
+    val keys = Aggregation.aggregate(rkey, ScopeMask(), extracted.structure.extra)
+    val tasks = Act.keyValues(extracted.structure)(keys)
+    val toRun = tasks map { case KeyValue(k,t) => t.map(v => KeyValue(k,v)) } join
+    val roots = tasks map { case KeyValue(k,_) => k }
+
+
+    val (newS, result) = withStreams(extracted.structure, state){ str =>
+      val transform = nodeView(state, str, roots, extra)
+      runTask(toRun, state,str, extracted.structure.index.triggers, config)(transform)
+    }
+    (newS, result)
+  }
+}

--- a/src/main/scala-sbt-1.0/Compat.scala
+++ b/src/main/scala-sbt-1.0/Compat.scala
@@ -6,7 +6,7 @@ import sbt.internal.{Act, Aggregation}
 import sbt.internal.Aggregation.{KeyValue}
 import sbt.internal.{Load => iLoad}
 import sbt.std.Transform.DummyTaskMap
-import sbt.{State, Result, TaskKey, EvaluateTask, ScopeMask}
+import sbt.{State, Result, TaskKey, EvaluateTask, ScopeMask, Scope, Reference, Select, Zero}
 
 object Compat {
   def runTaskAggregated[T](taskKey: TaskKey[T], state: State): (State, Result[Seq[KeyValue[T]]]) = {
@@ -31,5 +31,15 @@ object Compat {
     (newS, result)
   }
 
-  val Load = iLoad
+  def projectScope(project: Reference): Scope = Scope(Select(project), Zero, Zero, Zero)
+
+  type StructureIndex = sbt.internal.StructureIndex
+  type BuildStructure = sbt.internal.BuildStructure
+  val BuildStreams = sbt.internal.BuildStreams
+  type BuildUtil[Proj] = sbt.internal.BuildUtil[Proj]
+  val BuildUtil = sbt.internal.BuildUtil
+  val Index = sbt.internal.Index
+  type KeyIndex = sbt.internal.KeyIndex
+  val KeyIndex = sbt.internal.KeyIndex
+  type LoadedBuildUnit = sbt.internal.LoadedBuildUnit
 }

--- a/src/main/scala-sbt-1.0/Compat.scala
+++ b/src/main/scala-sbt-1.0/Compat.scala
@@ -69,7 +69,11 @@ object Compat {
   }
 
   type Command = sbt.Exec
-  implicit def command2String(command:Command) = command.commandLine
+  implicit def command2String(command: Command) = command.commandLine
+  implicit def string2Exex(s: String): Command = sbt.Exec(s, None, None)
+
+  // for doge integration test
+  object CrossPerProjectPlugin extends AutoPlugin
 
   // type aliases
   type StructureIndex = sbt.internal.StructureIndex

--- a/src/main/scala-sbt-1.0/Compat.scala
+++ b/src/main/scala-sbt-1.0/Compat.scala
@@ -41,7 +41,7 @@ object Compat {
     // getPublishTo fails if no publish repository is set up.
     val ex = st.extract
     val ref = ex.get(thisProjectRef)
-    Classpaths.getPublishTo(ex.get(publishTo in Global in ref))
+    Classpaths.getPublishTo(ex.runTask((publishTo in Global in ref), st)._2)
     st
   }
 

--- a/src/main/scala-sbt-1.0/Compat.scala
+++ b/src/main/scala-sbt-1.0/Compat.scala
@@ -55,7 +55,7 @@ object Compat {
 
   def crossVersions(st: State): Seq[String] = {
     // copied from https://github.com/sbt/sbt/blob/2d7ec47b13e02526174f897cca0aef585bd7b128/main/src/main/scala/sbt/Cross.scala#L40
-    val proj = Project.extract(state.value)
+    val proj = Project.extract(st)
     import proj._
     crossVersions(proj, currentRef)
   }

--- a/src/main/scala-sbt-1.0/Compat.scala
+++ b/src/main/scala-sbt-1.0/Compat.scala
@@ -2,11 +2,11 @@ package sbtrelease
 
 import sbt.internal.Aggregation.KeyValue
 import sbt.EvaluateTask.{extractedTaskConfig, nodeView, runTask, withStreams}
-import sbt.Keys.{publishTo, scalaHome, scalaVersion, thisProjectRef}
+import sbt.Keys._
 import sbt.internal.{Act, Aggregation}
 import sbt.internal.Aggregation.KeyValue
 import sbt.std.Transform.DummyTaskMap
-import sbt.{AttributeKey, Classpaths, EvaluateTask, Global, Reference, Result, Scope, ScopeMask, Select, Setting, State, TaskKey, Zero}
+import sbt._
 import sbt.Def.ScopedKey
 
 object Compat {
@@ -52,6 +52,21 @@ object Compat {
       case ScopedKey(Scope(_, Zero, Zero, _), key) if keys.contains(key) => true
       case _ => false
     }
+
+  def crossVersions(st: State): Seq[String] = {
+    // copied from https://github.com/sbt/sbt/blob/2d7ec47b13e02526174f897cca0aef585bd7b128/main/src/main/scala/sbt/Cross.scala#L40
+    val proj = Project.extract(state.value)
+    import proj._
+    crossVersions(proj, currentRef)
+  }
+
+  private def crossVersions(extracted: Extracted, proj: ProjectRef): Seq[String] = {
+    import extracted._
+    (crossScalaVersions in proj get structure.data) getOrElse {
+      // reading scalaVersion is a one-time deal
+      (scalaVersion in proj get structure.data).toSeq
+    }
+  }
 
   // type aliases
   type StructureIndex = sbt.internal.StructureIndex

--- a/src/main/scala-sbt-1.0/Compat.scala
+++ b/src/main/scala-sbt-1.0/Compat.scala
@@ -4,6 +4,7 @@ import sbt.internal.Aggregation.KeyValue
 import sbt.EvaluateTask.{extractedTaskConfig, nodeView, runTask, withStreams}
 import sbt.internal.{Act, Aggregation}
 import sbt.internal.Aggregation.{KeyValue}
+import sbt.internal.{Load => iLoad}
 import sbt.std.Transform.DummyTaskMap
 import sbt.{State, Result, TaskKey, EvaluateTask, ScopeMask}
 
@@ -29,4 +30,6 @@ object Compat {
     }
     (newS, result)
   }
+
+  val Load = iLoad
 }

--- a/src/main/scala-sbt-1.0/Compat.scala
+++ b/src/main/scala-sbt-1.0/Compat.scala
@@ -1,0 +1,32 @@
+package sbtrelease
+
+import sbt.internal.Aggregation.KeyValue
+import sbt.EvaluateTask.{extractedTaskConfig, nodeView, runTask, withStreams}
+import sbt.internal.{Act, Aggregation}
+import sbt.internal.Aggregation.{KeyValue}
+import sbt.std.Transform.DummyTaskMap
+import sbt.{State, Result, TaskKey, EvaluateTask, ScopeMask}
+
+object Compat {
+  def runTaskAggregated[T](taskKey: TaskKey[T], state: State): (State, Result[Seq[KeyValue[T]]]) = {
+    import EvaluateTask._
+    import Utilities._
+
+    val extra = DummyTaskMap(Nil)
+    val extracted = state.extract
+    val config = extractedTaskConfig(extracted, extracted.structure, state)
+
+    val rkey = Utilities.resolve(taskKey.scopedKey, extracted)
+    val keys = Aggregation.aggregate(rkey, ScopeMask(), extracted.structure.extra)
+    val tasks = Act.keyValues(extracted.structure)(keys)
+    val toRun = tasks map { case KeyValue(k,t) => t.map(v => KeyValue(k,v)) } join
+    val roots = tasks map { case KeyValue(k,_) => k }
+
+
+    val (newS, result) = withStreams(extracted.structure, state){ str =>
+      val transform = nodeView(state, str, roots, extra)
+      runTask(toRun, state,str, extracted.structure.index.triggers, config)(transform)
+    }
+    (newS, result)
+  }
+}

--- a/src/main/scala-sbt-1.0/Compat.scala
+++ b/src/main/scala-sbt-1.0/Compat.scala
@@ -68,6 +68,9 @@ object Compat {
     }
   }
 
+  type Command = sbt.Exec
+  implicit def command2String(command:Command) = command.commandLine
+
   // type aliases
   type StructureIndex = sbt.internal.StructureIndex
   type BuildStructure = sbt.internal.BuildStructure

--- a/src/main/scala-sbt-1.0/Compat.scala
+++ b/src/main/scala-sbt-1.0/Compat.scala
@@ -2,11 +2,12 @@ package sbtrelease
 
 import sbt.internal.Aggregation.KeyValue
 import sbt.EvaluateTask.{extractedTaskConfig, nodeView, runTask, withStreams}
-import sbt.Keys.{publishTo, thisProjectRef}
+import sbt.Keys.{publishTo, scalaHome, scalaVersion, thisProjectRef}
 import sbt.internal.{Act, Aggregation}
 import sbt.internal.Aggregation.KeyValue
 import sbt.std.Transform.DummyTaskMap
-import sbt.{Classpaths, EvaluateTask, Reference, Result, Scope, ScopeMask, Select, State, TaskKey, Zero, Global}
+import sbt.{AttributeKey, Classpaths, EvaluateTask, Global, Reference, Result, Scope, ScopeMask, Select, Setting, State, TaskKey, Zero}
+import sbt.Def.ScopedKey
 
 object Compat {
 
@@ -45,6 +46,12 @@ object Compat {
   }
 
   val FailureCommand = sbt.Exec("--failure--", None, None)
+
+  def excludeKeys(keys: Set[AttributeKey[_]]): Setting[_] => Boolean =
+    _.key match {
+      case ScopedKey(Scope(_, Zero, Zero, _), key) if keys.contains(key) => true
+      case _ => false
+    }
 
   // type aliases
   type StructureIndex = sbt.internal.StructureIndex

--- a/src/main/scala-sbt-1.0/Compat.scala
+++ b/src/main/scala-sbt-1.0/Compat.scala
@@ -44,6 +44,8 @@ object Compat {
     st
   }
 
+  val FailureCommand = sbt.Exec("--failure--", None, None)
+
   // type aliases
   type StructureIndex = sbt.internal.StructureIndex
   type BuildStructure = sbt.internal.BuildStructure

--- a/src/main/scala/Load.scala
+++ b/src/main/scala/Load.scala
@@ -1,7 +1,8 @@
 package sbtrelease
 
 import sbt.Keys.{resolvedScoped, streams}
-import sbt.{AttributeKey, Def, Global, InputTask, Project, Reference, Scope, ScopedKey, Select, Setting, Settings, Show, Task, Keys, URI, ~>}
+import sbt.{AttributeKey, Def, Global, InputTask, Project, Reference, Scope, Select, Setting, Settings, Show, Task, Keys, URI, ~>}
+import sbt.Def.ScopedKey
 
 // sbt.Load was made private in sbt 1.0
 // the core developers recommend copying the required methods: https://github.com/sbt/sbt/issues/3296#issuecomment-315218050

--- a/src/main/scala/Load.scala
+++ b/src/main/scala/Load.scala
@@ -1,0 +1,68 @@
+package sbtrelease
+
+import sbt.Keys.{resolvedScoped, streams}
+import sbt.{AttributeKey, Def, Global, InputTask, Project, Reference, Scope, ScopedKey, Select, Setting, Settings, Show, Task, Keys, URI, ~>}
+
+// sbt.Load was made private in sbt 1.0
+// the core developers recommend copying the required methods: https://github.com/sbt/sbt/issues/3296#issuecomment-315218050
+object Load {
+
+  import Compat._
+
+  def transformSettings(thisScope: Scope, uri: URI, rootProject: URI => String, settings: Seq[Setting[_]]): Seq[Setting[_]] =
+    Project.transform(Scope.resolveScope(thisScope, uri, rootProject), settings)
+  // Reevaluates settings after modifying them.  Does not recompile or reload any build components.
+  def reapply(newSettings: Seq[Setting[_]], structure: BuildStructure)(implicit display: Show[ScopedKey[_]]): BuildStructure =
+  {
+    val transformed = finalTransforms(newSettings)
+    val newData = Def.make(transformed)(structure.delegates, structure.scopeLocal, display)
+    val newIndex = structureIndex(newData, transformed, index => BuildUtil(structure.root, structure.units, index, newData), structure.units)
+    val newStreams = BuildStreams.mkStreams(structure.units, structure.root, newData)
+    new BuildStructure(units = structure.units, root = structure.root, settings = transformed, data = newData, index = newIndex, streams = newStreams, delegates = structure.delegates, scopeLocal = structure.scopeLocal)
+  }
+
+  // map dependencies on the special tasks:
+  // 1. the scope of 'streams' is the same as the defining key and has the task axis set to the defining key
+  // 2. the defining key is stored on constructed tasks: used for error reporting among other things
+  // 3. resolvedScoped is replaced with the defining key as a value
+  // Note: this must be idempotent.
+  def finalTransforms(ss: Seq[Setting[_]]): Seq[Setting[_]] =
+  {
+    def mapSpecial(to: ScopedKey[_]) = new (ScopedKey ~> ScopedKey) {
+      def apply[T](key: ScopedKey[T]) =
+        if (key.key == streams.key)
+          ScopedKey(Scope.fillTaskAxis(Scope.replaceThis(to.scope)(key.scope), to.key), key.key)
+        else key
+    }
+    def setDefining[T] = (key: ScopedKey[T], value: T) => value match {
+      case tk: Task[t]      => setDefinitionKey(tk, key).asInstanceOf[T]
+      case ik: InputTask[t] => ik.mapTask(tk => setDefinitionKey(tk, key)).asInstanceOf[T]
+      case _                => value
+    }
+    def setResolved(defining: ScopedKey[_]) = new (ScopedKey ~> Option) {
+      def apply[T](key: ScopedKey[T]): Option[T] =
+        key.key match {
+          case resolvedScoped.key => Some(defining.asInstanceOf[T])
+          case _                  => None
+        }
+    }
+    ss.map(s => s mapConstant setResolved(s.key) mapReferenced mapSpecial(s.key) mapInit setDefining)
+  }
+  def structureIndex(data: Settings[Scope], settings: Seq[Setting[_]], extra: KeyIndex => BuildUtil[_], projects: Map[URI, LoadedBuildUnit]): StructureIndex =
+  {
+    val keys = Index.allKeys(settings)
+    val attributeKeys = Index.attributeKeys(data) ++ keys.map(_.key)
+    val scopedKeys = keys ++ data.allKeys((s, k) => ScopedKey(s, k)).toVector
+    val projectsMap = projects.mapValues(_.defined.keySet)
+    val keyIndex = KeyIndex(scopedKeys.toVector, projectsMap)
+    val aggIndex = KeyIndex.aggregate(scopedKeys.toVector, extra(keyIndex), projectsMap)
+    new StructureIndex(Index.stringToKeyMap(attributeKeys), Index.taskToKeyMap(data), Index.triggers(data), keyIndex, aggIndex)
+  }
+
+  def setDefinitionKey[T](tk: Task[T], key: ScopedKey[_]): Task[T] =
+    if (isDummy(tk)) tk else Task(tk.info.set(Keys.taskDefinitionKey, key), tk.work)
+
+  private def isDummy(t: Task[_]): Boolean = t.info.attributes.get(isDummyTask) getOrElse false
+  private val Invisible = Int.MaxValue
+  private val isDummyTask = AttributeKey[Boolean]("is-dummy-task", "Internal: used to identify dummy tasks.  sbt injects values for these tasks at the start of task execution.", Invisible)
+}

--- a/src/main/scala/ReleaseExtra.scala
+++ b/src/main/scala/ReleaseExtra.scala
@@ -111,7 +111,13 @@ object ReleaseStateTransformations {
     if ( hasModifiedFiles ) sys.error( "Aborting release: unstaged modified files" )
     if ( hasUntrackedFiles && !extracted.get( releaseIgnoreUntrackedFiles ) )
     {
-        sys.error( "Aborting release: untracked files. Remove them or specify 'releaseIgnoreUntrackedFiles := true' in settings" )
+        sys.error(
+          s"""Aborting release: untracked files. Remove them or specify 'releaseIgnoreUntrackedFiles := true' in settings
+            |
+            |Untracked files:
+            |
+            |${vcs(st).untrackedFiles.mkString(" - ", "\n", "")}
+          """.stripMargin )
     }
 
     st.log.info("Starting release process off commit: " + vcs(st).currentHash)

--- a/src/main/scala/ReleaseExtra.scala
+++ b/src/main/scala/ReleaseExtra.scala
@@ -285,6 +285,7 @@ object ReleaseStateTransformations {
 		BuiltinCommands.reapply(newSession, structure, state)
   }
 
+  def crossExclude(s: Setting[_]): Boolean = Compat.excludeKeys(Set(scalaVersion.key, scalaHome.key))(s)
 
   // This is a copy of the state function for the command Cross.switchVersion
   private[sbtrelease] def switchScalaVersion(state: State, version: String): State = {
@@ -292,7 +293,7 @@ object ReleaseStateTransformations {
     import x._
     state.log.info("Setting scala version to " + version)
     val add = (scalaVersion in GlobalScope := version) :: (scalaHome in GlobalScope := None) :: Nil
-    val cleared = session.mergeSettings.filterNot(Cross.crossExclude)
+    val cleared = session.mergeSettings.filterNot(crossExclude)
     val newStructure = Load.reapply(add ++ cleared, structure)
     Project.setProject(session, newStructure, state)
   }

--- a/src/main/scala/ReleaseExtra.scala
+++ b/src/main/scala/ReleaseExtra.scala
@@ -8,7 +8,6 @@ import sbt.Package.ManifestAttributes
 import annotation.tailrec
 import ReleasePlugin.autoImport._
 import ReleaseKeys._
-import Compat.Load
 
 import sys.process.ProcessLogger
 
@@ -284,7 +283,7 @@ object ReleaseStateTransformations {
     val extracted = state.extract
     import extracted._
 
-    val append = Load.transformSettings(Load.projectScope(currentRef), currentRef.build, rootProject, settings)
+    val append = Load.transformSettings(Compat.projectScope(currentRef), currentRef.build, rootProject, settings)
 
     // We don't want even want to be able to save the settings that are applied to the session during the release cycle.
     // Just using an empty string works fine and in case the user calls `session save`, empty lines will be generated.

--- a/src/main/scala/ReleaseExtra.scala
+++ b/src/main/scala/ReleaseExtra.scala
@@ -10,6 +10,8 @@ import annotation.tailrec
 import ReleasePlugin.autoImport._
 import ReleaseKeys._
 
+import sys.process.ProcessLogger
+
 object ReleaseStateTransformations {
   import Utilities._
 

--- a/src/main/scala/ReleaseExtra.scala
+++ b/src/main/scala/ReleaseExtra.scala
@@ -254,13 +254,7 @@ object ReleaseStateTransformations {
 
   lazy val publishArtifacts = ReleaseStep(
     action = runPublishArtifactsAction,
-    check = st => {
-      // getPublishTo fails if no publish repository is set up.
-      val ex = st.extract
-      val ref = ex.get(thisProjectRef)
-      Classpaths.getPublishTo(ex.get(publishTo in Global in ref))
-      st
-    },
+    check = Compat.checkPublishTo,
     enableCrossBuild = true
   )
   private[sbtrelease] lazy val runPublishArtifactsAction = { st: State =>

--- a/src/main/scala/ReleaseExtra.scala
+++ b/src/main/scala/ReleaseExtra.scala
@@ -8,6 +8,7 @@ import sbt.Package.ManifestAttributes
 import annotation.tailrec
 import ReleasePlugin.autoImport._
 import ReleaseKeys._
+import Compat.Load
 
 import sys.process.ProcessLogger
 

--- a/src/main/scala/ReleaseExtra.scala
+++ b/src/main/scala/ReleaseExtra.scala
@@ -108,7 +108,15 @@ object ReleaseStateTransformations {
 
     val hasUntrackedFiles = vcs(st).hasUntrackedFiles
     val hasModifiedFiles = vcs(st).hasModifiedFiles
-    if ( hasModifiedFiles ) sys.error( "Aborting release: unstaged modified files" )
+    if ( hasModifiedFiles ) {
+      sys.error(
+        s"""Aborting release: unstaged modified files
+          |
+          |Modified files:
+          |
+          |${vcs(st).modifiedFiles.mkString(" - ", "\n", "")}
+        """.stripMargin )
+    }
     if ( hasUntrackedFiles && !extracted.get( releaseIgnoreUntrackedFiles ) )
     {
         sys.error(

--- a/src/main/scala/ReleaseExtra.scala
+++ b/src/main/scala/ReleaseExtra.scala
@@ -187,7 +187,8 @@ object ReleaseStateTransformations {
     val (commentState, comment) = st.extract.runTask(releaseTagComment, tagState)
     val tagToUse = findTag(tag)
     val sign = st.extract.get(releaseVcsSign)
-    tagToUse.foreach(vcs(commentState).tag(_, comment, sign) !! commentState.log)
+    val log = toProcessLogger(commentState)
+    tagToUse.foreach(vcs(commentState).tag(_, comment, sign) !! log)
 
 
     tagToUse map (t =>
@@ -204,8 +205,10 @@ object ReleaseStateTransformations {
     }
     val defaultChoice = extractDefault(st, "n")
 
+    val log = toProcessLogger(st)
+
     st.log.info("Checking remote [%s] ..." format vcs(st).trackingRemote)
-    if (vcs(st).checkRemote(vcs(st).trackingRemote) ! st.log != 0) {
+    if (vcs(st).checkRemote(vcs(st).trackingRemote) ! log != 0) {
       defaultChoice orElse SimpleReader.readLine("Error while checking remote. Still continue (y/n)? [n] ") match {
         case Yes() => // do nothing
         case _ => sys.error("Aborting the release!")

--- a/src/main/scala/ReleaseExtra.scala
+++ b/src/main/scala/ReleaseExtra.scala
@@ -301,7 +301,7 @@ object ReleaseStateTransformations {
   private[sbtrelease] def runCrossBuild(func: State => State): State => State = { state =>
     val x = Project.extract(state)
     import x._
-    val versions = Cross.crossVersions(state)
+    val versions = Compat.crossVersions(state)
     val current = scalaVersion in currentRef get structure.data
     val finalS = (state /: versions) {
       case (s, v) => func(switchScalaVersion(s, v))

--- a/src/main/scala/ReleasePlugin.scala
+++ b/src/main/scala/ReleasePlugin.scala
@@ -201,7 +201,11 @@ object ReleasePlugin extends AutoPlugin {
 
   override def trigger = allRequirements
 
-  val runtimeVersion = if (releaseUseGlobalVersion.value)(version in ThisBuild) else version
+  val runtimeVersion = Def.taskDyn {
+    Def.task {
+      if (releaseUseGlobalVersion.value)(version in ThisBuild) else version
+    }
+  }
 
   override def projectSettings = Seq[Setting[_]](
     releaseSnapshotDependencies := {

--- a/src/main/scala/ReleasePlugin.scala
+++ b/src/main/scala/ReleasePlugin.scala
@@ -203,7 +203,9 @@ object ReleasePlugin extends AutoPlugin {
   override def trigger = allRequirements
 
   val runtimeVersion = Def.task {
-    if (releaseUseGlobalVersion.value)(version in ThisBuild).value else version.value
+    val v1 = (version in ThisBuild).value
+    val v2 = version.value
+    if (releaseUseGlobalVersion.value) v1 else v2
   }
 
   override def projectSettings = Seq[Setting[_]](

--- a/src/main/scala/ReleasePlugin.scala
+++ b/src/main/scala/ReleasePlugin.scala
@@ -125,7 +125,7 @@ object ReleasePlugin extends AutoPlugin {
       val tagDefault = AttributeKey[Option[String]]("release-default-tag-exists-answer")
 
       private lazy val releaseCommandKey = "release"
-      private val FailureCommand = "--failure--"
+      private val FailureCommand = Compat.FailureCommand
 
       private[this] val WithDefaults: Parser[ParseResult] =
         (Space ~> token("with-defaults")) ^^^ ParseResult.WithDefaults

--- a/src/main/scala/ReleasePlugin.scala
+++ b/src/main/scala/ReleasePlugin.scala
@@ -201,7 +201,7 @@ object ReleasePlugin extends AutoPlugin {
 
   override def trigger = allRequirements
 
-  val runtimeVersion = if (releaseUseGlobalVersion.value)(version in ThisBuild).value else version.value
+  val runtimeVersion = if (releaseUseGlobalVersion.value)(version in ThisBuild) else version
 
   override def projectSettings = Seq[Setting[_]](
     releaseSnapshotDependencies := {
@@ -218,10 +218,10 @@ object ReleasePlugin extends AutoPlugin {
     releaseUseGlobalVersion := true,
     releaseCrossBuild := false,
 
-    releaseTagName := s"v$runtimeVersion",
-    releaseTagComment := s"Releasing $runtimeVersion",
+    releaseTagName := s"v${runtimeVersion.value}",
+    releaseTagComment := s"Releasing ${runtimeVersion.value}",
 
-    releaseCommitMessage := s"Setting version to $runtimeVersion",
+    releaseCommitMessage := s"Setting version to ${runtimeVersion.value}",
 
     releaseVcs := Vcs.detect(baseDirectory.value),
     releaseVcsSign := false,

--- a/src/main/scala/ReleasePlugin.scala
+++ b/src/main/scala/ReleasePlugin.scala
@@ -201,6 +201,8 @@ object ReleasePlugin extends AutoPlugin {
 
   override def trigger = allRequirements
 
+  val runtimeVersion = if (releaseUseGlobalVersion.value)(version in ThisBuild).value else version.value
+
   override def projectSettings = Seq[Setting[_]](
     releaseSnapshotDependencies := {
       val moduleIds = (managedClasspath in Runtime).value.flatMap(_.get(moduleID.key))
@@ -216,9 +218,10 @@ object ReleasePlugin extends AutoPlugin {
     releaseUseGlobalVersion := true,
     releaseCrossBuild := false,
 
-    releaseTagName := s"v${if (releaseUseGlobalVersion.value) (version in ThisBuild).value else version.value}",
-    releaseTagComment := s"Releasing ${if (releaseUseGlobalVersion.value) (version in ThisBuild).value else version.value}",
-    releaseCommitMessage := s"Setting version to ${if (releaseUseGlobalVersion.value) (version in ThisBuild).value else version.value}",
+    releaseTagName := s"v$runtimeVersion",
+    releaseTagComment := s"Releasing $runtimeVersion",
+
+    releaseCommitMessage := s"Setting version to $runtimeVersion",
 
     releaseVcs := Vcs.detect(baseDirectory.value),
     releaseVcsSign := false,

--- a/src/main/scala/ReleasePlugin.scala
+++ b/src/main/scala/ReleasePlugin.scala
@@ -202,10 +202,8 @@ object ReleasePlugin extends AutoPlugin {
 
   override def trigger = allRequirements
 
-  val runtimeVersion = Def.taskDyn {
-    Def.task {
-      if (releaseUseGlobalVersion.value)(version in ThisBuild) else version
-    }
+  val runtimeVersion = Def.task {
+    if (releaseUseGlobalVersion.value)(version in ThisBuild).value else version.value
   }
 
   override def projectSettings = Seq[Setting[_]](

--- a/src/main/scala/ReleasePlugin.scala
+++ b/src/main/scala/ReleasePlugin.scala
@@ -99,7 +99,7 @@ object ReleasePlugin extends AutoPlugin {
     /**
      * Convert the given command string to a release step action, preserving and invoking remaining commands
      */
-    def releaseStepCommandAndRemaining(command: Compat.Command): State => State = { st: State =>
+    def releaseStepCommandAndRemaining(command: String): State => State = { st: State =>
       import Compat._
       @annotation.tailrec
       def runCommand(command: Compat.Command, state: State): State = {

--- a/src/main/scala/ReleasePlugin.scala
+++ b/src/main/scala/ReleasePlugin.scala
@@ -99,9 +99,10 @@ object ReleasePlugin extends AutoPlugin {
     /**
      * Convert the given command string to a release step action, preserving and invoking remaining commands
      */
-    def releaseStepCommandAndRemaining(command: String): State => State = { st: State =>
+    def releaseStepCommandAndRemaining(command: Compat.Command): State => State = { st: State =>
+      import Compat._
       @annotation.tailrec
-      def runCommand(command: String, state: State): State = {
+      def runCommand(command: Compat.Command, state: State): State = {
         val nextState = Parser.parse(command, state.combinedParser) match {
           case Right(cmd) => cmd()
           case Left(msg) => throw sys.error(s"Invalid programmatic input:\n$msg")

--- a/src/main/scala/Vcs.scala
+++ b/src/main/scala/Vcs.scala
@@ -47,7 +47,7 @@ trait Vcs {
 
 object Vcs {
   def detect(dir: File): Option[Vcs] = {
-    Stream(Git, Mercurial, Subversion).flatMap(comp => comp.isRepository(dir).map(comp.mkVcs(_))).headOption
+    Stream(Git, Mercurial, Subversion).flatMap(comp => comp.isRepository(dir).map(comp.mkVcs)).headOption
   }
 }
 

--- a/src/main/scala/Vcs.scala
+++ b/src/main/scala/Vcs.scala
@@ -3,6 +3,8 @@ package sbtrelease
 import sbt._
 import java.io.File
 
+import sys.process.{ Process, ProcessBuilder, ProcessLogger }
+
 trait Vcs {
   val commandName: String
 
@@ -31,15 +33,15 @@ trait Vcs {
   }
 
   protected val devnull: ProcessLogger = new ProcessLogger {
-    def info(s: => String): Unit = {}
-    def error(s: => String): Unit = {}
-    def buffer[T](f: => T): T = f
+    override def buffer[T](f: => T): T = f
+    override def out(s: => String): Unit = ()
+    override def err(s: => String): Unit = ()
   }
 
   def stdErrorToStdOut(delegate: ProcessLogger): ProcessLogger = new ProcessLogger {
-    def info(s: => String) = delegate.info(s)
-    def error(s: => String) = delegate.info(s)
-    def buffer[T](f: => T): T = delegate.buffer(f)
+    override def buffer[T](f: => T): T = delegate.buffer(f)
+    override def out(s: => String): Unit = delegate.out(s)
+    override def err(s: => String): Unit = delegate.err(s)
   }
 }
 

--- a/src/main/scala/Vcs.scala
+++ b/src/main/scala/Vcs.scala
@@ -41,7 +41,7 @@ trait Vcs {
   def stdErrorToStdOut(delegate: ProcessLogger): ProcessLogger = new ProcessLogger {
     override def buffer[T](f: => T): T = delegate.buffer(f)
     override def out(s: => String): Unit = delegate.out(s)
-    override def err(s: => String): Unit = delegate.err(s)
+    override def err(s: => String): Unit = delegate.out(s)
   }
 }
 

--- a/src/main/scala/Vcs.scala
+++ b/src/main/scala/Vcs.scala
@@ -25,7 +25,8 @@ trait Vcs {
   def currentBranch: String
   def hasUntrackedFiles: Boolean = untrackedFiles.nonEmpty
   def untrackedFiles: Seq[String]
-  def hasModifiedFiles: Boolean
+  def hasModifiedFiles: Boolean = modifiedFiles.nonEmpty
+  def modifiedFiles: Seq[String]
 
   protected def executableName(command: String) = {
     val maybeOsName = sys.props.get("os.name").map(_.toLowerCase)
@@ -113,8 +114,7 @@ class Mercurial(val baseDir: File) extends Vcs with GitLike {
   def checkRemote(remote: String) = cmd("id", "-n")
 
   def untrackedFiles = cmd("status", "-un").lines
-
-  def hasModifiedFiles = cmd("status", "-mn").!!.trim.nonEmpty
+  def modifiedFiles = cmd("status", "-mn").lines
 }
 
 object Git extends VcsCompanion {
@@ -173,8 +173,7 @@ class Git(val baseDir: File) extends Vcs with GitLike {
   private def pushTags = cmd("push", "--tags", trackingRemote)
 
   def untrackedFiles = cmd("ls-files", "--other", "--exclude-standard").lines
-
-  def hasModifiedFiles : Boolean = cmd("ls-files", "--modified", "--exclude-standard").!!.trim.nonEmpty
+  def modifiedFiles = cmd("ls-files", "--modified", "--exclude-standard").lines
 }
 
 object Subversion extends VcsCompanion {
@@ -189,7 +188,7 @@ class Subversion(val baseDir: File) extends Vcs {
 
   override def cmd(args: Any*): ProcessBuilder = Process(exec +: args.map(_.toString), baseDir)
 
-  override def hasModifiedFiles: Boolean = cmd("status", "-q").!!.trim.nonEmpty
+  override def modifiedFiles = cmd("status", "-q").lines
   override def untrackedFiles = cmd("status").lines.filter(_.startsWith("?"))
 
   override def add(files: String*) = {

--- a/src/sbt-test/sbt-release/cross/test
+++ b/src/sbt-test/sbt-release/cross/test
@@ -1,3 +1,5 @@
+> update
+
 $ exec git init .
 $ exec git add .
 $ exec git commit -m init

--- a/src/sbt-test/sbt-release/cross/test
+++ b/src/sbt-test/sbt-release/cross/test
@@ -1,6 +1,7 @@
+$ exec git init .
+
 > update
 
-$ exec git init .
 $ exec git add .
 $ exec git commit -m init
 

--- a/src/sbt-test/sbt-release/doge-integration/build.sbt
+++ b/src/sbt-test/sbt-release/doge-integration/build.sbt
@@ -1,8 +1,10 @@
 import sbtrelease.ReleaseStateTransformations._
+import sbtrelease.Compat._
 
 val Scala210 = "2.10.6"
 
 val SupportedScalaVersions = Seq(Scala210, "2.11.8")
+
 
 val commonSettings = Seq(
   scalaVersion := Scala210,
@@ -14,11 +16,14 @@ val commonSettings = Seq(
   )
 )
 
-lazy val root = (project in file("."))
-  .settings(commonSettings: _*)
-  .settings(publishArtifact := false)
-  .aggregate(library, plugin)
-  .enablePlugins(CrossPerProjectPlugin)
+lazy val root = {
+  val r = (project in file("."))
+    .settings(commonSettings: _*)
+    .settings(publishArtifact := false)
+    .aggregate(library, plugin)
+  if(Keys.sbtVersion.value.startsWith("0.13")) r.enablePlugins(CrossPerProjectPlugin)
+  else r
+}
 
 // since it's a library it should be cross published
 val library = (project in file("library"))

--- a/src/sbt-test/sbt-release/doge-integration/build.sbt
+++ b/src/sbt-test/sbt-release/doge-integration/build.sbt
@@ -16,14 +16,11 @@ val commonSettings = Seq(
   )
 )
 
-lazy val root = {
-  val r = (project in file("."))
+lazy val root = (project in file("."))
     .settings(commonSettings: _*)
     .settings(publishArtifact := false)
     .aggregate(library, plugin)
-  if(Keys.sbtVersion.value.startsWith("0.13")) r.enablePlugins(CrossPerProjectPlugin)
-  else r
-}
+    .enablePlugins(CrossPerProjectPlugin)
 
 // since it's a library it should be cross published
 val library = (project in file("library"))

--- a/src/sbt-test/sbt-release/doge-integration/project/build.properties
+++ b/src/sbt-test/sbt-release/doge-integration/project/build.properties
@@ -1,1 +1,0 @@
-sbt.version=0.13.12

--- a/src/sbt-test/sbt-release/doge-integration/project/plugins.sbt
+++ b/src/sbt-test/sbt-release/doge-integration/project/plugins.sbt
@@ -1,6 +1,6 @@
 {
   // sbt-doge has been included in sbt 1.0 so this plugin is only available for 0.13
-  val sbtV = System.getProperty("plugin.version")
+  val sbtV = System.getProperty("sbt.version")
   if(sbtV.startsWith("0.13")) addSbtPlugin("com.eed3si9n" % "sbt-doge" % "0.1.5")
   // FIXME: find another noop that satisfies type requirements
   else libraryDependencies += "org.slf4j" % "slf4j-nop" % "1.7.21"

--- a/src/sbt-test/sbt-release/doge-integration/project/plugins.sbt
+++ b/src/sbt-test/sbt-release/doge-integration/project/plugins.sbt
@@ -1,6 +1,10 @@
-addSbtPlugin("com.eed3si9n" % "sbt-doge" % "0.1.5")
-
 {
+  // sbt-doge has been included in sbt 1.0 so this plugin is only available for 0.13
+  val sbtV = System.getProperty("plugin.version")
+  if(sbtV.startsWith("0.13")) addSbtPlugin("com.eed3si9n" % "sbt-doge" % "0.1.5")
+  // FIXME: find another noop that satisfies type requirements
+  else libraryDependencies += "org.slf4j" % "slf4j-nop" % "1.7.21"
+
   val pluginVersion = System.getProperty("plugin.version")
   if(pluginVersion == null)
     throw new RuntimeException("""|The system property 'plugin.version' is not defined.

--- a/src/sbt-test/sbt-release/doge-integration/test
+++ b/src/sbt-test/sbt-release/doge-integration/test
@@ -1,3 +1,10 @@
+$ exec git init .
+
+> update
+
+$ exec git add .
+$ exec git commit -m init
+
 > release
 $ exists artifacts/library/library_2.10/0.1.2/library_2.10-0.1.2.jar
 $ exists artifacts/library/library_2.11/0.1.2/library_2.11-0.1.2.jar

--- a/src/sbt-test/sbt-release/fail-test/build.sbt
+++ b/src/sbt-test/sbt-release/fail-test/build.sbt
@@ -4,4 +4,4 @@ releaseProcess := Seq[ReleaseStep](runTest, FailTest.createFile)
 
 scalaVersion := "2.10.3"
 
-libraryDependencies += "org.scalatest" % "scalatest_2.10" % "2.1.0" % "test"
+libraryDependencies += "org.scalatest" %% "scalatest" % "3.0.3" % "test"

--- a/src/sbt-test/sbt-release/mercurial/test
+++ b/src/sbt-test/sbt-release/mercurial/test
@@ -1,6 +1,7 @@
+$ exec hg init .
+
 > update
 
-$ exec hg init .
 $ exec hg add .
 $ exec hg commit -m init
 

--- a/src/sbt-test/sbt-release/mercurial/test
+++ b/src/sbt-test/sbt-release/mercurial/test
@@ -1,3 +1,5 @@
+> update
+
 $ exec hg init .
 $ exec hg add .
 $ exec hg commit -m init

--- a/src/sbt-test/sbt-release/skip-tests/build.sbt
+++ b/src/sbt-test/sbt-release/skip-tests/build.sbt
@@ -1,6 +1,6 @@
 import sbtrelease.ReleaseStateTransformations._
 
-libraryDependencies += "org.scalatest" %% "scalatest" % "2.2.6" % "test"
+libraryDependencies += "org.scalatest" %% "scalatest" % "3.0.3" % "test"
 
 releaseProcess := Seq(
   checkSnapshotDependencies,

--- a/src/sbt-test/sbt-release/skip-tests/test
+++ b/src/sbt-test/sbt-release/skip-tests/test
@@ -1,3 +1,5 @@
+> update
+
 $ exec git init .
 $ exec git add .
 $ exec git commit -m init

--- a/src/sbt-test/sbt-release/skip-tests/test
+++ b/src/sbt-test/sbt-release/skip-tests/test
@@ -1,6 +1,7 @@
+$ exec git init .
+
 > update
 
-$ exec git init .
 $ exec git add .
 $ exec git commit -m init
 

--- a/src/sbt-test/sbt-release/tag-default/build.sbt
+++ b/src/sbt-test/sbt-release/tag-default/build.sbt
@@ -1,6 +1,6 @@
 import sbtrelease.ReleaseStateTransformations._
 
-libraryDependencies += "org.scalatest" %% "scalatest" % "2.2.6" % "test"
+libraryDependencies += "org.scalatest" %% "scalatest" % "3.0.3" % "test"
 
 releaseProcess := Seq(
   checkSnapshotDependencies,

--- a/src/sbt-test/sbt-release/tag-default/test
+++ b/src/sbt-test/sbt-release/tag-default/test
@@ -1,3 +1,5 @@
+> update
+
 $ exec git init .
 $ exec git add .
 $ exec git commit -m init

--- a/src/sbt-test/sbt-release/tag-default/test
+++ b/src/sbt-test/sbt-release/tag-default/test
@@ -1,6 +1,7 @@
+$ exec git init .
+
 > update
 
-$ exec git init .
 $ exec git add .
 $ exec git commit -m init
 

--- a/src/sbt-test/sbt-release/with-defaults/test
+++ b/src/sbt-test/sbt-release/with-defaults/test
@@ -1,3 +1,5 @@
+> update
+
 $ exec git init .
 $ exec git add .
 $ exec git commit -m init

--- a/src/sbt-test/sbt-release/with-defaults/test
+++ b/src/sbt-test/sbt-release/with-defaults/test
@@ -1,6 +1,7 @@
+$ exec git init .
+
 > update
 
-$ exec git init .
 $ exec git add .
 $ exec git commit -m init
 


### PR DESCRIPTION
Fixes #198.

I took a stab at implementing sbt 1.0 cross building but I have hit a road block.

The compatibility class appears to not be found when I load the plugin. 

```
/home/travis/build/sbt/sbt-release/src/main/scala/ReleaseExtra.scala:19: not found: value Compat
val (newSt, result) = Compat.runTaskAggregated(releaseSnapshotDependencies in thisRef, st)                         
```
Is it possible that that has something to do with the fact that the plugin requires itself? Maybe during the recursive loading the `/src/scala-sbt-0.13` path is ignored?

/cc @dwijnand @xuwei-k 