### PR TITLE
First draft for an automatic README.md version update

### DIFF
--- a/src/main/scala/ReleaseExtra.scala
+++ b/src/main/scala/ReleaseExtra.scala
@@ -210,6 +210,48 @@ object ReleaseStateTransformations {
     ) getOrElse commentState
   }
 
+
+  lazy val updateReadme: ReleaseStep = ReleaseStep(updateReadmeStep)
+  private def updateReadmeStep(state: State): State = {
+    val extracted = Project.extract(state)
+    val releaseVersion = extracted.get(version)
+    val base = extracted.get(baseDirectory)
+    val readmeFile = base / "README.md"
+
+    val versionRegex = """(\d{1,2}\.\d{1,2}\.\d{1,2})""".r
+    val updatedReadmeContent = versionRegex.replaceAllIn(
+      IO.read(readmeFile),
+      releaseVersion
+    )
+
+    IO.write(readmeFile, updatedReadmeContent)
+    state
+  }
+
+  lazy val commitReadme: ReleaseStep = ReleaseStep(commitReadmeStep)
+  private def commitReadmeStep(state: State): State = {
+    val log = toProcessLogger(state)
+    val base = vcs(state).baseDir
+    val sign = Project.extract(state).get(releaseVcsSign)
+    val readmeFile = base / "README.md"
+
+    val relativePath = IO
+      .relativize(base, readmeFile)
+      .getOrElse(
+        "Version file [%s] is outside of this VCS repository with base directory [%s]!" format (readmeFile, base)
+      )
+
+    vcs(state).add(relativePath) !! log
+    val vcsAddOutput = (vcs(state).status !!).trim
+    if (vcsAddOutput.isEmpty) {
+      state.log.info("README.md hasn't been changed.")
+    } else {
+      vcs(state).commit("Update release version in readme", sign) ! log
+    }
+
+    state
+  }
+
   lazy val pushChanges: ReleaseStep = ReleaseStep(pushChangesAction, checkUpstream)
   private[sbtrelease] lazy val checkUpstream = { st: State =>
     if (!vcs(st).hasUpstream) {

--- a/src/sbt-test/sbt-release/update-readme/.gitignore
+++ b/src/sbt-test/sbt-release/update-readme/.gitignore
@@ -1,0 +1,2 @@
+target
+global/

--- a/src/sbt-test/sbt-release/update-readme/README.md
+++ b/src/sbt-test/sbt-release/update-readme/README.md
@@ -1,0 +1,7 @@
+# A project
+
+Add library in your `build.sbt`
+
+```scala
+libraryDependencies += "com.example" %% "lib" % "1.0.0"
+```

--- a/src/sbt-test/sbt-release/update-readme/build.sbt
+++ b/src/sbt-test/sbt-release/update-readme/build.sbt
@@ -1,0 +1,32 @@
+import sbtrelease.ReleaseStateTransformations._
+
+
+releaseProcess := Seq(
+  checkSnapshotDependencies,
+  inquireVersions,
+  runClean,
+  runTest,
+  setReleaseVersion,
+  commitReleaseVersion,
+  tagRelease,
+  updateReadme,
+  commitReadme,
+  setNextVersion,
+  commitNextVersion
+)
+
+TaskKey[Unit]("checkReadme") := {
+  val readmeFile = baseDirectory.value / "README.md"
+  val content = IO.read(readmeFile)
+
+  assert(content ==
+    """|# A project
+       |
+       |Add library in your `build.sbt`
+       |
+       |```scala
+       |libraryDependencies += "com.example" %% "lib" % "2.3.4"
+       |```
+       |""".stripMargin, s"Readme wasn't updated correctly\n\n$content")
+
+}

--- a/src/sbt-test/sbt-release/update-readme/project/build.sbt
+++ b/src/sbt-test/sbt-release/update-readme/project/build.sbt
@@ -1,0 +1,7 @@
+{
+  val pluginVersion = System.getProperty("plugin.version")
+  if(pluginVersion == null)
+    throw new RuntimeException("""|The system property 'plugin.version' is not defined.
+                                  |Specify this property using the scriptedLaunchOpts -D.""".stripMargin)
+  else addSbtPlugin("com.github.gseitz" % "sbt-release" % pluginVersion)
+}

--- a/src/sbt-test/sbt-release/update-readme/test
+++ b/src/sbt-test/sbt-release/update-readme/test
@@ -1,0 +1,10 @@
+$ exec git init .
+
+> update
+
+$ exec git add .
+$ exec git commit -m init
+
+> release release-version 2.3.4 next-version 2.3.5-SNAPSHOT
+
+> checkReadme

--- a/src/sbt-test/sbt-release/update-readme/version.sbt
+++ b/src/sbt-test/sbt-release/update-readme/version.sbt
@@ -1,0 +1,1 @@
+version in ThisBuild := "1.0.0"


### PR DESCRIPTION
Hi,

This PR is a draft for the following feature:

> Automatically update the version defined in the `README.md` to the released version

This is implemented via two additional release steps:

1. `updateReadme`
2. `commitReadme`

The implementation is yet missing some crucial parts

- [ ] configurable regex to find the version definition
- [ ] configurable README.md file ( necessary ? )
- [ ] documentation

WDYT?
