### PR TITLE
Fix #95

### DIFF
--- a/src/sbt-test/sbt-release/exit-code/.gitignore
+++ b/src/sbt-test/sbt-release/exit-code/.gitignore
@@ -1,0 +1,2 @@
+target
+global/

--- a/src/sbt-test/sbt-release/exit-code/build.sbt
+++ b/src/sbt-test/sbt-release/exit-code/build.sbt
@@ -1,0 +1,30 @@
+// import sbtrelease.ReleaseStateTransformations._
+import scala.sys.process.Process
+
+// credits for the test to: https://github.com/rossabaker/sbt-release-exit-code
+
+publishTo := Some(Resolver.file("file",  new File(Path.userHome.absolutePath+"/.m2/repository")))
+
+def checkExitCode(rp: String)(expected: Int) = {
+  val releaseProcess =
+    Process("sbt", Seq(s"-Dplugin.version=${System.getProperty("plugin.version")}",
+      s"set releaseProcess := $rp",
+      "release with-defaults")
+    )
+
+  val exitValue = releaseProcess.!
+
+  println(s"exit code is $exitValue and should be $expected")
+
+  assert(exitValue == expected)
+
+  ()
+}
+
+TaskKey[Unit]("checkExitCodes") := {
+  checkExitCode("Seq(sbtrelease.ReleaseStateTransformations.runTest)")(1)
+
+  checkExitCode("""Seq(releaseStepCommand("show version"))""")(0)
+
+  checkExitCode("""Seq(sbtrelease.ReleaseStateTransformations.runTest, releaseStepCommand("show version"))""")(1)
+}

--- a/src/sbt-test/sbt-release/exit-code/foo.scala
+++ b/src/sbt-test/sbt-release/exit-code/foo.scala
@@ -1,0 +1,1 @@
+This is NOT Scala

--- a/src/sbt-test/sbt-release/exit-code/project/build.sbt
+++ b/src/sbt-test/sbt-release/exit-code/project/build.sbt
@@ -1,0 +1,7 @@
+{
+  val pluginVersion = System.getProperty("plugin.version")
+  if(pluginVersion == null)
+    throw new RuntimeException("""|The system property 'plugin.version' is not defined.
+                                  |Specify this property using the scriptedLaunchOpts -D.""".stripMargin)
+  else addSbtPlugin("com.github.gseitz" % "sbt-release" % pluginVersion)
+}

--- a/src/sbt-test/sbt-release/exit-code/test
+++ b/src/sbt-test/sbt-release/exit-code/test
@@ -1,0 +1,8 @@
+$ exec git init .
+
+> update
+
+$ exec git add .
+$ exec git commit -m init
+
+> checkExitCodes


### PR DESCRIPTION
#95 is a long lasting issue with this plugin.
Someone have had to do it ...
The root cause of the problem is that insertion of `FailureCommand` on failing tasks is not enforced in the steps of the `releaseProcess`.

`sbt-scripted` is not able AFAIK to handle exit codes and it is not able to properly test this situation, that's why the test is hacked in that way, I'm open to suggestions; so far everything else I've tried failed to perform the check.

thanks to @rossabaker for the minimal repro I took as example to narrow down the issue.
