### PR TITLE
preserve the failure command on command and remaining

### DIFF
--- a/src/sbt-test/sbt-release/exit-code/build.sbt
+++ b/src/sbt-test/sbt-release/exit-code/build.sbt
@@ -5,6 +5,10 @@ import scala.sys.process.Process
 
 publishTo := Some(Resolver.file("file",  new File(Path.userHome.absolutePath+"/.m2/repository")))
 
+val failingTask = taskKey[Unit]("A task that will fail")
+
+failingTask :=  {throw new IllegalStateException("Meh")}
+
 def checkExitCode(rp: String)(expected: Int) = {
   val releaseProcess =
     Process("sbt", Seq(s"-Dplugin.version=${System.getProperty("plugin.version")}",
@@ -14,7 +18,8 @@ def checkExitCode(rp: String)(expected: Int) = {
 
   val exitValue = releaseProcess.!
 
-  println(s"exit code is $exitValue and should be $expected")
+  println("plugin version: " + System.getProperty("plugin.version"))
+  println(s"exit code is $exitValue and should be $expected in $rp")
 
   assert(exitValue == expected)
 
@@ -27,4 +32,8 @@ TaskKey[Unit]("checkExitCodes") := {
   checkExitCode("""Seq(releaseStepCommand("show version"))""")(0)
 
   checkExitCode("""Seq(sbtrelease.ReleaseStateTransformations.runTest, releaseStepCommand("show version"))""")(1)
+
+  checkExitCode("""Seq(releaseStepCommandAndRemaining("show version"))""")(0)
+
+  checkExitCode("""Seq(releaseStepCommandAndRemaining("failingTask"))""")(1)
 }


### PR DESCRIPTION
We need to add the failure command if it's present. If we're not doing
it we will exit with the error code `0` when expecting `1`.