### PR TITLE
Allow signoff of commits

### DIFF
--- a/src/main/scala/ReleaseExtra.scala
+++ b/src/main/scala/ReleaseExtra.scala
@@ -146,6 +146,7 @@ object ReleaseStateTransformations {
     val file = st.extract.get(releaseVersionFile).getCanonicalFile
     val base = vcs(st).baseDir.getCanonicalFile
     val sign = st.extract.get(releaseVcsSign)
+    val signOff = st.extract.get(releaseVcsSignOff)
     val relativePath = IO.relativize(base, file).getOrElse("Version file [%s] is outside of this VCS repository with base directory [%s]!" format(file, base))
 
     vcs(st).add(relativePath) !! log
@@ -153,7 +154,7 @@ object ReleaseStateTransformations {
 
     val newState = if (status.nonEmpty) {
       val (state, msg) = st.extract.runTask(releaseCommitMessage, st)
-      vcs(state).commit(msg, sign) ! log
+      vcs(state).commit(msg, sign, signOff) ! log
       state
     } else {
       // nothing to commit. this happens if the version.sbt file hasn't changed.

--- a/src/main/scala/ReleasePlugin.scala
+++ b/src/main/scala/ReleasePlugin.scala
@@ -23,6 +23,7 @@ object ReleasePlugin extends AutoPlugin {
     val releaseUseGlobalVersion = settingKey[Boolean]("Whether to use a global version")
     val releaseIgnoreUntrackedFiles = settingKey[Boolean]("Whether to ignore untracked files")
     val releaseVcsSign = settingKey[Boolean]("Whether to sign VCS commits and tags")
+    val releaseVcsSignOff = settingKey[Boolean]("Whether to signoff VCS commits")
 
     val releaseVcs = settingKey[Option[Vcs]]("The VCS to use")
     val releasePublishArtifactsAction = taskKey[Unit]("The action that should be performed to publish artifacts")
@@ -236,6 +237,7 @@ object ReleasePlugin extends AutoPlugin {
 
     releaseVcs := Vcs.detect(baseDirectory.value),
     releaseVcsSign := false,
+    releaseVcsSignOff := false,
 
     releaseVersionFile := baseDirectory.value / "version.sbt",
 


### PR DESCRIPTION
Some companies open source policies only allow you to use signoff commits (not to be confused by signed commits, signoff means adding a `Signed Off By ...` to the commit message, signing means using a PGP key to sign the commit)

This PR implements the signoff functionality, it also generalizes the `withSignFlag` functionality