### PR TITLE
Print offending version in version format error

### DIFF
--- a/src/main/scala/ReleaseExtra.scala
+++ b/src/main/scala/ReleaseExtra.scala
@@ -281,7 +281,7 @@ object ReleaseStateTransformations {
     else if (useDef) ver
     else SimpleReader.readLine(prompt format ver) match {
       case Some("") => ver
-      case Some(input) => Version(input).map(_.string).getOrElse(versionFormatError)
+      case Some(input) => Version(input).map(_.string).getOrElse(versionFormatError(input))
       case None => sys.error("No version provided!")
     }
   }

--- a/src/main/scala/ReleasePlugin.scala
+++ b/src/main/scala/ReleasePlugin.scala
@@ -222,10 +222,10 @@ object ReleasePlugin extends AutoPlugin {
       snapshots
     },
 
-    releaseVersion := { ver => Version(ver).map(_.withoutQualifier.string).getOrElse(versionFormatError) },
+    releaseVersion := { ver => Version(ver).map(_.withoutQualifier.string).getOrElse(versionFormatError(ver)) },
     releaseVersionBump := Version.Bump.default,
     releaseNextVersion := {
-      ver => Version(ver).map(_.bump(releaseVersionBump.value).asSnapshot.string).getOrElse(versionFormatError)
+      ver => Version(ver).map(_.bump(releaseVersionBump.value).asSnapshot.string).getOrElse(versionFormatError(ver))
     },
     releaseUseGlobalVersion := true,
     releaseCrossBuild := false,

--- a/src/main/scala/package.scala
+++ b/src/main/scala/package.scala
@@ -1,5 +1,5 @@
 package object sbtrelease {
   type Versions = (String, String)
 
-  def versionFormatError = sys.error("Version format is not compatible with " + Version.VersionR.pattern.toString)
+  def versionFormatError(version: String) = sys.error(s"Version [$version] format is not compatible with " + Version.VersionR.pattern.toString)
 }


### PR DESCRIPTION
When versions are derived/generated, this can be helpful for figuring
out what the failing version number was.