### PR TITLE
Fix the generation of git flags

### DIFF
--- a/src/main/scala/Vcs.scala
+++ b/src/main/scala/Vcs.scala
@@ -146,18 +146,12 @@ class Git(val baseDir: File) extends Vcs with GitLike {
 
   private final case class GitFlag(on: Boolean, flag: String)
 
-  private def withFlags(flags: Seq[GitFlag])(args: String*) = {
-    val appended = flags.map{gitFlag =>
-      if (gitFlag.on)
-        s"-${gitFlag.flag}"
-      else
-        ""
-    }.mkString(" ")
+  private def withFlags(flags: Seq[GitFlag])(args: String*): Seq[String] = {
+    val appended = flags.collect {
+      case GitFlag(true, flag) => s"-$flag"
+    }
 
-    if (appended.trim.nonEmpty)
-      args :+ appended
-    else
-      args
+    args ++ appended
   }
 
   def commit(message: String, sign: Boolean, signOff: Boolean) = {


### PR DESCRIPTION
Tested manually by publishing locally and dummy-releasing a project. Tried all combinations of `releaseVcsSign` and `releaseVcsSignOff`.

Fixes #243, i.e. the case where only `-S` is set.

In the case that both flags (`-S` and `-s`) are set, the previous implementation was combining them both into a single argument `-S -s`, which I don't think would have worked either. This PR also fixes that case.