### PR TITLE
fixed unchecked SNAPSHOT for internal projects during release

### DIFF
--- a/src/main/scala/ReleasePlugin.scala
+++ b/src/main/scala/ReleasePlugin.scala
@@ -217,7 +217,7 @@ object ReleasePlugin extends AutoPlugin {
 
   override def projectSettings = Seq[Setting[_]](
     releaseSnapshotDependencies := {
-      val moduleIds = (managedClasspath in Runtime).value.flatMap(_.get(moduleID.key))
+      val moduleIds = (dependencyClasspath in Runtime).value.flatMap(_.get(moduleID.key))
       val snapshots = moduleIds.filter(m => m.isChanging || m.revision.endsWith("-SNAPSHOT"))
       snapshots
     },


### PR DESCRIPTION
internal SBT modules as dependencies are not checked for SNAPSHOT versions currently.  