### PR TITLE
Explain default values at prompt

### DIFF
--- a/src/main/scala/ReleaseExtra.scala
+++ b/src/main/scala/ReleaseExtra.scala
@@ -41,6 +41,8 @@ object ReleaseStateTransformations {
     val releaseFunc = extracted.runTask(releaseVersion, st)._2
     val suggestedReleaseV = releaseFunc(currentV)
 
+    st.log.info("Press enter to use the default value")
+
     //flatten the Option[Option[String]] as the get returns an Option, and the value inside is an Option
     val releaseV = readVersion(suggestedReleaseV, "Release version [%s] : ", useDefs, st.get(commandLineReleaseVersion).flatten)
 


### PR DESCRIPTION
As a junior developer, I was not familiar with the convention of putting default values at the command line prompt in square brackets. The clarification added here (and shown below) would have made the process smoother for me, and hopefully will in the future for other newcomers.

```
[info] Starting release process off commit: 31a267bf645511d1817cae531b2a2e6e2ac76d41
[info] Checking remote [origin] ...
[info] Press enter to use the default value
Release version [3.0.5] :
```