### PR TITLE
Separate variable for the commit message of the `nextVersion` commit

### DIFF
--- a/src/main/scala/ReleasePlugin.scala
+++ b/src/main/scala/ReleasePlugin.scala
@@ -18,6 +18,7 @@ object ReleasePlugin extends AutoPlugin {
     val releaseTagName = taskKey[String]("The name of the tag")
     val releaseTagComment = taskKey[String]("The comment to use when tagging")
     val releaseCommitMessage = taskKey[String]("The commit message to use when tagging")
+    val releaseNextCommitMessage = taskKey[String]("The commit message to use for next iteration")
     val releaseCrossBuild = settingKey[Boolean]("Whether the release should be cross built")
     val releaseVersionFile = settingKey[File]("The file to write the version to")
     val releaseUseGlobalVersion = settingKey[Boolean]("Whether to use a global version")
@@ -234,6 +235,7 @@ object ReleasePlugin extends AutoPlugin {
     releaseTagComment := s"Releasing ${runtimeVersion.value}",
 
     releaseCommitMessage := s"Setting version to ${runtimeVersion.value}",
+    releaseNextCommitMessage := s"Setting version to ${runtimeVersion.value}",
 
     releaseVcs := Vcs.detect(baseDirectory.value),
     releaseVcsSign := false,


### PR DESCRIPTION
It seems that `sbt-release` plugin uses the same commit message template for the commit that is tagged with the version and the commit that contains the incremented version number. Following PR introduces the variable `releaseNextCommitMessage` which controls the commit message of the step `commitNextVersion`.

The variable contains the same default as `releaseCommitMessage` in order to maintain backward compatibility (`s"Setting version to ${runtimeVersion.value}"`).

Following release should now be possible.

```
commit b6cc17f5cbb4a776f169393127c26dcd0501270d (HEAD -> master)
Author: Author Name <author@example.com>
Date:   Tue Oct 1 17:00:01 2019 +0000

    Setting next development version to 0.1.1-SNAPSHOT

commit 89f092a0509fad19cf1f626d76ec09aaa38fcee6 (tag: v0.1.0)
Author: Author Name <author@example.com>
Date:   Tue Oct 1 17:00:00 2019 +0000

    Releasing version 0.1.0
```

