### PR TITLE
Removed publish check

### DIFF
--- a/src/main/scala-sbt-0.13/Compat.scala
+++ b/src/main/scala-sbt-0.13/Compat.scala
@@ -38,10 +38,13 @@ object Compat {
 
   // checking if publishTo is configured
   def checkPublishTo(st: State ): State = {
-    // getPublishTo fails if no publish repository is set up.
+    // getPublishTo fails if no publish repository is set up for projects with `skip in publish := false`.
     val ex = st.extract
     val ref = ex.get(thisProjectRef)
-    Classpaths.getPublishTo(ex.get(publishTo in Global in ref))
+    val (_, skipPublish) = ex.runTask(skip in publish in ref, st)
+    if (!skipPublish) {
+      Classpaths.getPublishTo(ex.get(publishTo in Global in ref))
+    }
     st
   }
 

--- a/src/main/scala-sbt-1.0/Compat.scala
+++ b/src/main/scala-sbt-1.0/Compat.scala
@@ -38,10 +38,13 @@ object Compat {
 
   // checking if publishTo is configured
   def checkPublishTo(st: State): State = {
-    // getPublishTo fails if no publish repository is set up.
+    // getPublishTo fails if no publish repository is set up for projects with `skip in publish := false`.
     val ex = st.extract
     val ref = ex.get(thisProjectRef)
-    Classpaths.getPublishTo(ex.runTask((publishTo in Global in ref), st)._2)
+    val (_, skipPublish) = ex.runTask(skip in publish in ref, st)
+    if (!skipPublish) {
+      Classpaths.getPublishTo(ex.runTask((publishTo in Global in ref), st)._2)
+    }
     st
   }
 


### PR DESCRIPTION
Fix for #184 

This check was a problem for a multi-module publish for projects with a `root` project which should not be published.

Without this check `publish` action will work for projects with correctly configured publishing and will be ignored for projects without publishing (like aggregation projects). It will also work for a cross-publishing.