### PR TITLE
Use Scaladex badge to show sbt-version compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # sbt-release
 This sbt plugin provides a customizable release process that you can add to your project.
 
-[![Maven Central](https://maven-badges.herokuapp.com/maven-central/com.github.sbt/sbt-release/badge.svg)](https://maven-badges.herokuapp.com/maven-central/com.github.sbt/sbt-release/)
+[![sbt-release Scala version support](https://index.scala-lang.org/sbt/sbt-release/sbt-release/latest-by-scala-version.svg?targetType=Sbt)](https://index.scala-lang.org/sbt/sbt-release/sbt-release)
 
 **Notice:** This README contains information for the latest release. Please refer to the documents for a specific version by looking up the respective [tag](https://github.com/sbt/sbt-release/tags).
 


### PR DESCRIPTION
The Scaladex badge is a bit more helpful than the Maven Central badge - it summarises which versions of sbt are supported by sbt-release (and what the latest sbt-release version is for each of those sbt versions):

[![sbt-release Scala version support](https://index.scala-lang.org/sbt/sbt-release/sbt-release/latest-by-scala-version.svg?targetType=Sbt)](https://index.scala-lang.org/sbt/sbt-release/sbt-release)

More details on the badge format here: https://github.com/scalacenter/scaladex/pull/660 (with some extra changes to better support sbt in https://github.com/scalacenter/scaladex/pull/674).