### PR TITLE
fix: next with qualifier strategy not incrementing version correctly

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ target
 project/target
 .idea
 .idea_modules
+.bsp

--- a/README.md
+++ b/README.md
@@ -111,14 +111,14 @@ In the section *Customizing the release process* we take a look at how to define
 
 ### Convenient versioning
 
-As of version 0.8, *sbt-release* comes with four strategies for computing the next snapshot version via the `releaseVersionBump` setting. These strategies are defined in `sbtrelease.Version.Bump`. By default, the `Next` strategy is used:
+As of version 0.8, *sbt-release* comes with six strategies for computing the next snapshot version via the `releaseVersionBump` setting. These strategies are defined in `sbtrelease.Version.Bump`. By default, the `Next` strategy is used:
 
  * `Major`: always bumps the *major* part of the version
  * `Minor`: always bumps the *minor* part of the version
  * `Bugfix`: always bumps the *bugfix* part of the version
  * `Nano`: always bumps the *nano* part of the version
- * `Next`: bumps the last version part (e.g. `0.17` -> `0.18`, `0.11.7` -> `0.11.8`, `3.22.3.4.91` -> `3.22.3.4.92`)
-
+ * `Next`: bumps the last version part, excluding the qualifier (e.g. `0.17` -> `0.18`, `0.11.7` -> `0.11.8`, `3.22.3.4.91` -> `3.22.3.4.92`, `1.0.0-RC1` -> `1.0.1`)
+ * `NextWithQualifer`: bumps the last version part, including the qualifier (e.g. `0.17` -> `0.18`, `0.11.7` -> `0.11.8`, `3.22.3.4.91` -> `3.22.3.4.92`, `1.0.0-RC1` -> `1.0.0-RC2`)   
 Example:
 
     releaseVersionBump := sbtrelease.Version.Bump.Major
@@ -139,16 +139,19 @@ val releaseNextVersion : SettingKey[String => String]
 The default settings make use of the helper class [`Version`](https://github.com/sbt/sbt-release/blob/master/src/main/scala/Version.scala) that ships with *sbt-release*.
 
 ```scala
-// strip the qualifier off the input version, eg. 1.2.1-SNAPSHOT -> 1.2.1
-releaseVersion     := { ver => Version(ver).map(_.withoutQualifier.string).getOrElse(versionFormatError(ver)) }
 
-// strip the snapshot off the input version, eg. 1.2.1-SNAPSHOT -> 1.2.1
-releaseVersion     := { ver => Version(ver).map(_.withoutSnapshot.string).getOrElse(versionFormatError(ver)) }
-
+releaseVersion := {
+  releaseVersionBump.value match {
+    // strip the snapshot off the input version, eg. 1.2.1-RC1-SNAPSHOT -> 1.2.1-RC1
+    case _ @ Version.Bump.NextWithQualifier => { ver => Version(ver).map(_.withoutSnapshot.string).getOrElse(versionFormatError(ver)) }
+    // strip the whole qualifier off the input version, eg. 1.2.1-RC1-SNAPSHOT -> 1.2.1
+    case _ => { ver => Version(ver).map(_.withoutQualifier.string).getOrElse(versionFormatError(ver)) }
+  }
+},
 // bump the version and append '-SNAPSHOT', eg. 1.2.1 -> 1.3.0-SNAPSHOT
 releaseNextVersion := {
   ver => Version(ver).map(_.bump(releaseVersionBump.value).asSnapshot.string).getOrElse(versionFormatError(ver))
-},
+}
 ```
 
 If you want to customize the versioning, keep the following in mind:

--- a/src/main/scala/ReleasePlugin.scala
+++ b/src/main/scala/ReleasePlugin.scala
@@ -223,7 +223,12 @@ object ReleasePlugin extends AutoPlugin {
       snapshots
     },
 
-    releaseVersion := { ver => Version(ver).map(_.withoutQualifier.string).getOrElse(versionFormatError(ver)) },
+    releaseVersion := {
+      releaseVersionBump.value match {
+        case _ @ Version.Bump.NextWithQualifier => { ver => Version(ver).map(_.withoutSnapshot.string).getOrElse(versionFormatError(ver)) }
+        case _ => { ver => Version(ver).map(_.withoutQualifier.string).getOrElse(versionFormatError(ver)) }
+      }
+    },
     releaseVersionBump := Version.Bump.default,
     releaseNextVersion := {
       ver => Version(ver).map(_.bump(releaseVersionBump.value).asSnapshot.string).getOrElse(versionFormatError(ver))


### PR DESCRIPTION
The `NextWithQualifier` strategy is not currently incrementing the version correctly. This PR updates the default implementation of `releaseVersion` to react to the value of `releaseVersionBump` where the strategy is defined. It also updates the README to reflect these changes.