### PR TITLE
feat: adding prerelease version increments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,3 @@ target
 project/target
 .idea
 .idea_modules
-.bsp

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ target
 project/target
 .idea
 .idea_modules
+.bsp

--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ As of version 0.8, *sbt-release* comes with some strategies for computing the ne
  * `Minor`: always bumps the *minor* part of the version
  * `Bugfix`: always bumps the *bugfix* part of the version
  * `Nano`: always bumps the *nano* part of the version
- * `Next`: bumps the last version part (e.g. `0.17` -> `0.18`, `0.11.7` -> `0.11.8`, `3.22.3.4.91` -> `3.22.3.4.92`)
+ * `Next`: bumps the last version part (e.g. `0.17` -> `0.18`, `0.11.7` -> `0.11.8`, `3.22.3.4.91` -> `3.22.3.4.92`, `2.0.0-RC1` -> `2.0.0-RC2`)
 
 Example:
 

--- a/README.md
+++ b/README.md
@@ -117,8 +117,8 @@ As of version 0.8, *sbt-release* comes with several strategies for computing the
  * `Minor`: always bumps the *minor* part of the version
  * `Bugfix`: always bumps the *bugfix* part of the version
  * `Nano`: always bumps the *nano* part of the version
- * `NextPrerelease` (**default**): bumps the last version part, including the qualifier (e.g. `0.17` -> `0.18`, `0.11.7` -> `0.11.8`, `3.22.3.4.91` -> `3.22.3.4.92`, `1.0.0-RC1` -> `1.0.0-RC2`)
- * `NextStable`: bumps exactly like `NextPrerelease` except that the qualifier is excluded (e.g. `1.0.0-RC1` -> `1.0.0`)
+ * `Next` (**default**): bumps the last version part, including the qualifier (e.g. `0.17` -> `0.18`, `0.11.7` -> `0.11.8`, `3.22.3.4.91` -> `3.22.3.4.92`, `1.0.0-RC1` -> `1.0.0-RC2`)
+ * `NextStable`: bumps exactly like `Next` except that any prerelease qualifier is excluded (e.g. `1.0.0-RC1` -> `1.0.0`)
 
 Users can set their preferred versioning strategy in `build.sbt` as follows:
 ```sbt
@@ -142,8 +142,8 @@ These derived versions are used for the suggestions/defaults in the prompt and f
 Let's take a look at the types:
 
 ```scala
-val releaseVersion     : SettingKey[String => String]
-val releaseNextVersion : SettingKey[String => String]
+val releaseVersion     : TaskKey[String => String]
+val releaseNextVersion : TaskKey[String => String]
 ```
 
 If you want to customize the versioning, keep the following in mind:

--- a/README.md
+++ b/README.md
@@ -117,17 +117,21 @@ As of version 0.8, *sbt-release* comes with several strategies for computing the
  * `Minor`: always bumps the *minor* part of the version
  * `Bugfix`: always bumps the *bugfix* part of the version
  * `Nano`: always bumps the *nano* part of the version
- * `Next`: bumps the last version part, excluding the qualifier (e.g. `0.17` -> `0.18`, `0.11.7` -> `0.11.8`, `3.22.3.4.91` -> `3.22.3.4.92`, `1.0.0-RC1` -> `1.0.1`, `1.0.0-RC1` -> `1.0.0-RC2`)
-Example:
+ * `NextPrerelease` (**default**): bumps the last version part, including the qualifier (e.g. `0.17` -> `0.18`, `0.11.7` -> `0.11.8`, `3.22.3.4.91` -> `3.22.3.4.92`, `1.0.0-RC1` -> `1.0.0-RC2`)
+ * `NextStable`: bumps exactly like `NextPrerelease` except that the qualifier is excluded (e.g. `1.0.0-RC1` -> `1.0.0`)
 
-    releaseVersionBump := sbtrelease.Version.Bump.Major
+Users can set their preferred versioning strategy in `build.sbt` as follows:
+```sbt
+releaseVersionBump := sbtrelease.Version.Bump.Major
+```
 
 ### Default Versioning
 
 The default settings make use of the helper class [`Version`](https://github.com/sbt/sbt-release/blob/master/src/main/scala/Version.scala) that ships with *sbt-release*.
 
-`releaseVersion`: The current version in version.sbt, without the "-SNAPSHOT" ending,
-`releaseNextVersion`: The "bumped" version according to the "Next" strategy (explained above)
+`releaseVersion`: The current version in version.sbt, without the "-SNAPSHOT" ending. So, if `version.sbt` contains `1.0.0-SNAPSHOT`, the release version will be set to `1.0.0`.
+
+`releaseNextVersion`: The "bumped" version according to the versioning strategy (explained above), including the `-SNAPSHOT` ending. So, if `releaseVersion` is `1.0.0`, `releaseNextVersion` will be `1.0.1-SNAPSHOT`.
 
 ### Custom Versioning
 

--- a/README.md
+++ b/README.md
@@ -142,6 +142,9 @@ The default settings make use of the helper class [`Version`](https://github.com
 // strip the qualifier off the input version, eg. 1.2.1-SNAPSHOT -> 1.2.1
 releaseVersion     := { ver => Version(ver).map(_.withoutQualifier.string).getOrElse(versionFormatError(ver)) }
 
+// strip the snapshot off the input version, eg. 1.2.1-SNAPSHOT -> 1.2.1
+releaseVersion     := { ver => Version(ver).map(_.withoutSnapshot.string).getOrElse(versionFormatError(ver)) }
+
 // bump the version and append '-SNAPSHOT', eg. 1.2.1 -> 1.3.0-SNAPSHOT
 releaseNextVersion := {
   ver => Version(ver).map(_.bump(releaseVersionBump.value).asSnapshot.string).getOrElse(versionFormatError(ver))

--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ As of version 0.8, *sbt-release* comes with some strategies for computing the ne
  * `Minor`: always bumps the *minor* part of the version
  * `Bugfix`: always bumps the *bugfix* part of the version
  * `Nano`: always bumps the *nano* part of the version
- * `Next`: bumps the last version part (e.g. `0.17` -> `0.18`, `0.11.7` -> `0.11.8`, `3.22.3.4.91` -> `3.22.3.4.92`, `2.0.0-RC1` -> `2.0.0-RC2`)
+ * `Next`: bumps the last version part (e.g. `0.17` -> `0.18`, `0.11.7` -> `0.11.8`, `3.22.3.4.91` -> `3.22.3.4.92`)
 
 Example:
 
@@ -139,6 +139,9 @@ val releaseNextVersion : SettingKey[String => String]
 The default settings make use of the helper class [`Version`](https://github.com/sbt/sbt-release/blob/master/src/main/scala/Version.scala) that ships with *sbt-release*.
 
 ```scala
+// strip the qualifier off the input version, eg. 1.2.1-SNAPSHOT -> 1.2.1
+releaseVersion     := { ver => Version(ver).map(_.withoutQualifier.string).getOrElse(versionFormatError(ver)) }
+
 // strip the snapshot off the input version, eg. 1.2.1-SNAPSHOT -> 1.2.1
 releaseVersion     := { ver => Version(ver).map(_.withoutSnapshot.string).getOrElse(versionFormatError(ver)) }
 

--- a/README.md
+++ b/README.md
@@ -109,21 +109,27 @@ A cross release behaves analogous to using the `+` command:
 
 In the section *Customizing the release process* we take a look at how to define a `ReleaseStep` to participate in a cross build.
 
-### Convenient versioning
+### Versioning Strategies
 
-As of version 0.8, *sbt-release* comes with some strategies for computing the next snapshot version via the `releaseVersionBump` setting. These strategies are defined in `sbtrelease.Version.Bump`. By default, the `Next` strategy is used:
+As of version 0.8, *sbt-release* comes with several strategies for computing the next snapshot version via the `releaseVersionBump` setting. These strategies are defined in `sbtrelease.Version.Bump`. By default, the `Next` strategy is used:
 
  * `Major`: always bumps the *major* part of the version
  * `Minor`: always bumps the *minor* part of the version
  * `Bugfix`: always bumps the *bugfix* part of the version
  * `Nano`: always bumps the *nano* part of the version
- * `Next`: bumps the last version part, excluding the qualifier (e.g. `0.17` -> `0.18`, `0.11.7` -> `0.11.8`, `3.22.3.4.91` -> `3.22.3.4.92`, `1.0.0-RC1` -> `1.0.1`)
- * `NextWithQualifer`: bumps the last version part, including the qualifier (e.g. `0.17` -> `0.18`, `0.11.7` -> `0.11.8`, `3.22.3.4.91` -> `3.22.3.4.92`, `1.0.0-RC1` -> `1.0.0-RC2`)   
+ * `Next`: bumps the last version part, excluding the qualifier (e.g. `0.17` -> `0.18`, `0.11.7` -> `0.11.8`, `3.22.3.4.91` -> `3.22.3.4.92`, `1.0.0-RC1` -> `1.0.1`, `1.0.0-RC1` -> `1.0.0-RC2`)
 Example:
 
     releaseVersionBump := sbtrelease.Version.Bump.Major
 
-### Custom versioning
+### Default Versioning
+
+The default settings make use of the helper class [`Version`](https://github.com/sbt/sbt-release/blob/master/src/main/scala/Version.scala) that ships with *sbt-release*.
+
+`releaseVersion`: The current version in version.sbt, without the "-SNAPSHOT" ending,
+`releaseNextVersion`: The "bumped" version according to the "Next" strategy (explained above)
+
+### Custom Versioning
 
 *sbt-release* comes with two settings for deriving the release version and the next development version from a given version.
 
@@ -134,24 +140,6 @@ Let's take a look at the types:
 ```scala
 val releaseVersion     : SettingKey[String => String]
 val releaseNextVersion : SettingKey[String => String]
-```
-
-The default settings make use of the helper class [`Version`](https://github.com/sbt/sbt-release/blob/master/src/main/scala/Version.scala) that ships with *sbt-release*.
-
-```scala
-
-releaseVersion := {
-  releaseVersionBump.value match {
-    // strip the snapshot off the input version, eg. 1.2.1-RC1-SNAPSHOT -> 1.2.1-RC1
-    case _ @ Version.Bump.NextWithQualifier => { ver => Version(ver).map(_.withoutSnapshot.string).getOrElse(versionFormatError(ver)) }
-    // strip the whole qualifier off the input version, eg. 1.2.1-RC1-SNAPSHOT -> 1.2.1
-    case _ => { ver => Version(ver).map(_.withoutQualifier.string).getOrElse(versionFormatError(ver)) }
-  }
-},
-// bump the version and append '-SNAPSHOT', eg. 1.2.1 -> 1.3.0-SNAPSHOT
-releaseNextVersion := {
-  ver => Version(ver).map(_.bump(releaseVersionBump.value).asSnapshot.string).getOrElse(versionFormatError(ver))
-}
 ```
 
 If you want to customize the versioning, keep the following in mind:

--- a/README.md
+++ b/README.md
@@ -142,9 +142,6 @@ The default settings make use of the helper class [`Version`](https://github.com
 // strip the qualifier off the input version, eg. 1.2.1-SNAPSHOT -> 1.2.1
 releaseVersion     := { ver => Version(ver).map(_.withoutQualifier.string).getOrElse(versionFormatError(ver)) }
 
-// strip the snapshot off the input version, eg. 1.2.1-SNAPSHOT -> 1.2.1
-releaseVersion     := { ver => Version(ver).map(_.withoutSnapshot.string).getOrElse(versionFormatError(ver)) }
-
 // bump the version and append '-SNAPSHOT', eg. 1.2.1 -> 1.3.0-SNAPSHOT
 releaseNextVersion := {
   ver => Version(ver).map(_.bump(releaseVersionBump.value).asSnapshot.string).getOrElse(versionFormatError(ver))

--- a/README.md
+++ b/README.md
@@ -139,8 +139,8 @@ val releaseNextVersion : SettingKey[String => String]
 The default settings make use of the helper class [`Version`](https://github.com/sbt/sbt-release/blob/master/src/main/scala/Version.scala) that ships with *sbt-release*.
 
 ```scala
-// strip the qualifier off the input version, eg. 1.2.1-SNAPSHOT -> 1.2.1
-releaseVersion     := { ver => Version(ver).map(_.withoutQualifier.string).getOrElse(versionFormatError(ver)) }
+// strip the snapshot off the input version, eg. 1.2.1-SNAPSHOT -> 1.2.1
+releaseVersion     := { ver => Version(ver).map(_.withoutSnapshot.string).getOrElse(versionFormatError(ver)) }
 
 // bump the version and append '-SNAPSHOT', eg. 1.2.1 -> 1.3.0-SNAPSHOT
 releaseNextVersion := {

--- a/build.sbt
+++ b/build.sbt
@@ -33,7 +33,6 @@ enablePlugins(SbtPlugin)
 scriptedLaunchOpts := {
   scriptedLaunchOpts.value ++ Seq("-Xmx1024M", "-XX:MaxPermSize=256M", "-Dplugin.version=" + version.value)
 }
-
 scriptedBufferLog := false
 
 pomExtra := {

--- a/build.sbt
+++ b/build.sbt
@@ -5,7 +5,6 @@ name := "sbt-release"
 
 homepage := Some(url("https://github.com/sbt/sbt-release"))
 licenses := Seq("Apache-2.0" -> url("http://www.apache.org/licenses/LICENSE-2.0"))
-scalaVersion := "2.12.18"
 publishMavenStyle := true
 scalacOptions ++= Seq("-deprecation", "-feature", "-language:implicitConversions")
 

--- a/build.sbt
+++ b/build.sbt
@@ -33,7 +33,10 @@ enablePlugins(SbtPlugin)
 scriptedLaunchOpts := {
   scriptedLaunchOpts.value ++ Seq("-Xmx1024M", "-XX:MaxPermSize=256M", "-Dplugin.version=" + version.value)
 }
+
 scriptedBufferLog := false
+scriptedParallelInstances := 9 //Set to be equal to the number of scripted tests
+scriptedBatchExecution := true
 
 pomExtra := {
   <developers>{

--- a/build.sbt
+++ b/build.sbt
@@ -5,7 +5,7 @@ name := "sbt-release"
 
 homepage := Some(url("https://github.com/sbt/sbt-release"))
 licenses := Seq("Apache-2.0" -> url("http://www.apache.org/licenses/LICENSE-2.0"))
-
+scalaVersion := "2.12.18"
 publishMavenStyle := true
 scalacOptions ++= Seq("-deprecation", "-feature", "-language:implicitConversions")
 

--- a/build.sbt
+++ b/build.sbt
@@ -5,6 +5,7 @@ name := "sbt-release"
 
 homepage := Some(url("https://github.com/sbt/sbt-release"))
 licenses := Seq("Apache-2.0" -> url("http://www.apache.org/licenses/LICENSE-2.0"))
+
 publishMavenStyle := true
 scalacOptions ++= Seq("-deprecation", "-feature", "-language:implicitConversions")
 

--- a/build.sbt
+++ b/build.sbt
@@ -35,8 +35,6 @@ scriptedLaunchOpts := {
 }
 
 scriptedBufferLog := false
-scriptedParallelInstances := 9 //Set to be equal to the number of scripted tests
-scriptedBatchExecution := true
 
 pomExtra := {
   <developers>{

--- a/src/main/scala/ReleasePlugin.scala
+++ b/src/main/scala/ReleasePlugin.scala
@@ -223,10 +223,12 @@ object ReleasePlugin extends AutoPlugin {
       snapshots
     },
 
-    releaseVersion := {
-      releaseVersionBump.value match {
-        case _ @ Version.Bump.NextWithQualifier => { ver => Version(ver).map(_.withoutSnapshot.string).getOrElse(versionFormatError(ver)) }
-        case _ => { ver => Version(ver).map(_.withoutQualifier.string).getOrElse(versionFormatError(ver)) }
+    releaseVersion := { rawVersion =>
+      val version = Version(rawVersion).getOrElse(versionFormatError(rawVersion))
+      if (version.isSnapshot) {
+        version.withoutSnapshot.string
+      } else {
+        expectedSnapshotVersionError(version.string)
       }
     },
     releaseVersionBump := Version.Bump.default,

--- a/src/main/scala/ReleasePlugin.scala
+++ b/src/main/scala/ReleasePlugin.scala
@@ -226,23 +226,22 @@ object ReleasePlugin extends AutoPlugin {
       snapshots
     },
     releaseVersion := { rawVersion =>
-
       Version(rawVersion).map { version =>
         releaseVersionBump.value match {
-          case Bump.NextPrerelease | Bump.Next =>
+          case Bump.Next =>
             if (version.isSnapshot) {
-              version.withoutSnapshot.string
+              version.withoutSnapshot.unapply
             } else {
               expectedSnapshotVersionError(rawVersion)
             }
-          case _ => version.withoutQualifier.string
+          case _ => version.withoutQualifier.unapply
         }
       }
       .getOrElse(versionFormatError(rawVersion))
     },
     releaseVersionBump := Version.Bump.default,
     releaseNextVersion := {
-      ver => Version(ver).map(_.bump(releaseVersionBump.value).asSnapshot.string).getOrElse(versionFormatError(ver))
+      ver => Version(ver).map(_.bump(releaseVersionBump.value).asSnapshot.unapply).getOrElse(versionFormatError(ver))
     },
     releaseUseGlobalVersion := true,
     releaseCrossBuild := false,

--- a/src/main/scala/ReleasePlugin.scala
+++ b/src/main/scala/ReleasePlugin.scala
@@ -223,7 +223,12 @@ object ReleasePlugin extends AutoPlugin {
       snapshots
     },
 
-    releaseVersion := { ver => Version(ver).map(_.withoutQualifier.string).getOrElse(versionFormatError(ver)) },
+    releaseVersion := {
+      releaseVersionBump.value match {
+        case _ @ Version.Bump.NextWithQualifier => { ver => Version(ver).map(_.withoutSnapshot.string).getOrElse(versionFormatError(ver)) }
+        case _ => { ver => Version(ver).map(_.withoutQualifier.string).getOrElse(versionFormatError(ver)) }
+      }
+    },
     releaseVersionBump := Version.Bump.default,
     releaseNextVersion := {
       ver => Version(ver).map(_.bump(releaseVersionBump.value).asSnapshot.string).getOrElse(versionFormatError(ver))

--- a/src/main/scala/ReleasePlugin.scala
+++ b/src/main/scala/ReleasePlugin.scala
@@ -73,7 +73,7 @@ object ReleasePlugin extends AutoPlugin {
       withStreams(extracted.structure, st) { str =>
         val nv = nodeView(st, str, key :: Nil)
         val (newS, result) = runTask(task, st, str, extracted.structure.index.triggers, config)(nv)
-        (newS, processResult2(result))
+        (newS, processResult(result, newS.log))
       }._1
     }
 
@@ -223,7 +223,7 @@ object ReleasePlugin extends AutoPlugin {
       snapshots
     },
 
-    releaseVersion := { ver => Version(ver).map(_.withoutSnapshot.string).getOrElse(versionFormatError(ver)) },
+    releaseVersion := { ver => Version(ver).map(_.withoutQualifier.string).getOrElse(versionFormatError(ver)) },
     releaseVersionBump := Version.Bump.default,
     releaseNextVersion := {
       ver => Version(ver).map(_.bump(releaseVersionBump.value).asSnapshot.string).getOrElse(versionFormatError(ver))

--- a/src/main/scala/ReleasePlugin.scala
+++ b/src/main/scala/ReleasePlugin.scala
@@ -73,7 +73,7 @@ object ReleasePlugin extends AutoPlugin {
       withStreams(extracted.structure, st) { str =>
         val nv = nodeView(st, str, key :: Nil)
         val (newS, result) = runTask(task, st, str, extracted.structure.index.triggers, config)(nv)
-        (newS, processResult(result, newS.log))
+        (newS, processResult2(result))
       }._1
     }
 
@@ -223,7 +223,7 @@ object ReleasePlugin extends AutoPlugin {
       snapshots
     },
 
-    releaseVersion := { ver => Version(ver).map(_.withoutQualifier.string).getOrElse(versionFormatError(ver)) },
+    releaseVersion := { ver => Version(ver).map(_.withoutSnapshot.string).getOrElse(versionFormatError(ver)) },
     releaseVersionBump := Version.Bump.default,
     releaseNextVersion := {
       ver => Version(ver).map(_.bump(releaseVersionBump.value).asSnapshot.string).getOrElse(versionFormatError(ver))

--- a/src/main/scala/ReleasePlugin.scala
+++ b/src/main/scala/ReleasePlugin.scala
@@ -7,8 +7,6 @@ import sbt.complete.DefaultParsers.*
 import sbt.complete.Parser
 import sbtrelease.Version.Bump
 
-import scala.annotation.nowarn
-
 object ReleasePlugin extends AutoPlugin {
 
   object autoImport {
@@ -218,7 +216,6 @@ object ReleasePlugin extends AutoPlugin {
     if (releaseUseGlobalVersion.value) v1 else v2
   }
 
-  @nowarn("msg=object Next in object Bump is deprecated*")
   override def projectSettings = Seq[Setting[_]](
     releaseSnapshotDependencies := {
       val moduleIds = (Runtime / managedClasspath).value.flatMap(_.get(moduleID.key))

--- a/src/main/scala/Version.scala
+++ b/src/main/scala/Version.scala
@@ -8,36 +8,11 @@ object Version {
   }
 
   object Bump {
-
-    /**
-     * Strategy to always bump the major version by default. Ex. 1.0.0 would be bumped to 2.0.0
-     */
-    case object Major extends Bump { def bump: Version => Version = _.bumpMajor }
-    /**
-     * Strategy to always bump the minor version by default. Ex. 1.0.0 would be bumped to 1.1.0
-     */
-    case object Minor extends Bump { def bump: Version => Version = _.bumpMinor }
-    /**
-     * Strategy to always bump the bugfix version by default. Ex. 1.0.0 would be bumped to 1.0.1
-     */
-    case object Bugfix extends Bump { def bump: Version => Version = _.bumpBugfix }
-    /**
-     * Strategy to always bump the nano version by default. Ex. 1.0.0.0 would be bumped to 1.0.0.1
-     */
-    case object Nano extends Bump { def bump: Version => Version = _.bumpNano }
-
-    case object Next extends Bump { def bump: Version => Version = _.bump }
-    /**
-     * Strategy to always increment to the next version from smallest to greatest
-     * Ex:
-     * Major: 1 becomes 2
-     * Minor: 1.0 becomes 1.1
-     * Bugfix: 1.0.0 becomes 1.0.1
-     * Nano: 1.0.0.0 becomes 1.0.0.1
-     * Qualifier with version number: 1.0-RC1 becomes 1.0-RC2
-     * Qualifier without version number: 1.0-alpha becomes 1.0
-     */
-    case object NextWithQualifier extends Bump { def bump: Version => Version = _.bumpWithQualifier }
+    case object Major extends Bump { def bump = _.bumpMajor }
+    case object Minor extends Bump { def bump = _.bumpMinor }
+    case object Bugfix extends Bump { def bump = _.bumpBugfix }
+    case object Nano extends Bump { def bump = _.bumpNano }
+    case object Next extends Bump { def bump = _.bump }
 
     val default = Next
   }
@@ -71,30 +46,6 @@ case class Version(major: Int, subversions: Seq[Int], qualifier: Option[String])
       .getOrElse(bumpedMajor)
   }
 
-  def bumpWithQualifier = {
-    val maybeBumpedPrerelease = qualifier.collect {
-      case rawQualifier @ Version.PreReleaseQualifierR() =>
-        val qualifierEndsWithNumberRegex = """[0-9]*$""".r
-
-        val opt = for {
-          versionNumberQualifierStr <- qualifierEndsWithNumberRegex.findFirstIn(rawQualifier)
-          versionNumber <- Try(versionNumberQualifierStr.toInt)
-            .toRight(new Exception(s"Version number not parseable to a number. Version number received: $versionNumberQualifierStr"))
-            .toOption
-          newVersionNumber = versionNumber + 1
-          newQualifier = rawQualifier.replaceFirst(versionNumberQualifierStr, newVersionNumber.toString)
-        } yield Version(major, subversions, Some(newQualifier))
-
-        opt.getOrElse(copy(qualifier = None))
-    }
-    def maybeBumpedLastSubversion = bumpSubversionOpt(subversions.length-1)
-    def bumpedMajor = copy(major = major + 1)
-
-    maybeBumpedPrerelease
-      .orElse(maybeBumpedLastSubversion)
-      .getOrElse(bumpedMajor)
-  }
-
   def bumpMajor  = copy(major = major + 1, subversions = Seq.fill(subversions.length)(0))
   def bumpMinor  = maybeBumpSubversion(0)
   def bumpBugfix = maybeBumpSubversion(1)
@@ -114,19 +65,7 @@ case class Version(major: Int, subversions: Seq[Int], qualifier: Option[String])
   def bump(bumpType: Version.Bump): Version = bumpType.bump(this)
 
   def withoutQualifier = copy(qualifier = None)
-  def asSnapshot = copy(qualifier = qualifier.map { qualifierStr =>
-    s"$qualifierStr-SNAPSHOT"
-  }.orElse(Some("-SNAPSHOT")))
-
-  def withoutSnapshot: Version = copy(qualifier = qualifier.flatMap { qualifierStr =>
-    val snapshotRegex = """-SNAPSHOT""".r
-    val newQualifier = snapshotRegex.replaceFirstIn(qualifierStr, "")
-    if (newQualifier == qualifierStr) {
-      None
-    } else {
-      Some(newQualifier)
-    }
-  })
+  def asSnapshot = copy(qualifier = Some("-SNAPSHOT"))
 
   def string = "" + major + mkString(subversions) + qualifier.getOrElse("")
 

--- a/src/main/scala/Version.scala
+++ b/src/main/scala/Version.scala
@@ -8,11 +8,36 @@ object Version {
   }
 
   object Bump {
-    case object Major extends Bump { def bump = _.bumpMajor }
-    case object Minor extends Bump { def bump = _.bumpMinor }
-    case object Bugfix extends Bump { def bump = _.bumpBugfix }
-    case object Nano extends Bump { def bump = _.bumpNano }
-    case object Next extends Bump { def bump = _.bump }
+
+    /**
+     * Strategy to always bump the major version by default. Ex. 1.0.0 would be bumped to 2.0.0
+     */
+    case object Major extends Bump { def bump: Version => Version = _.bumpMajor }
+    /**
+     * Strategy to always bump the minor version by default. Ex. 1.0.0 would be bumped to 1.1.0
+     */
+    case object Minor extends Bump { def bump: Version => Version = _.bumpMinor }
+    /**
+     * Strategy to always bump the bugfix version by default. Ex. 1.0.0 would be bumped to 1.0.1
+     */
+    case object Bugfix extends Bump { def bump: Version => Version = _.bumpBugfix }
+    /**
+     * Strategy to always bump the nano version by default. Ex. 1.0.0.0 would be bumped to 1.0.0.1
+     */
+    case object Nano extends Bump { def bump: Version => Version = _.bumpNano }
+
+    case object Next extends Bump { def bump: Version => Version = _.bump }
+    /**
+     * Strategy to always increment to the next version from smallest to greatest
+     * Ex:
+     * Major: 1 becomes 2
+     * Minor: 1.0 becomes 1.1
+     * Bugfix: 1.0.0 becomes 1.0.1
+     * Nano: 1.0.0.0 becomes 1.0.0.1
+     * Qualifier with version number: 1.0-RC1 becomes 1.0-RC2
+     * Qualifier without version number: 1.0-alpha becomes 1.0
+     */
+    case object NextWithQualifier extends Bump { def bump: Version => Version = _.bumpWithQualifier }
 
     val default = Next
   }
@@ -46,6 +71,30 @@ case class Version(major: Int, subversions: Seq[Int], qualifier: Option[String])
       .getOrElse(bumpedMajor)
   }
 
+  def bumpWithQualifier = {
+    val maybeBumpedPrerelease = qualifier.collect {
+      case rawQualifier @ Version.PreReleaseQualifierR() =>
+        val qualifierEndsWithNumberRegex = """[0-9]*$""".r
+
+        val opt = for {
+          versionNumberQualifierStr <- qualifierEndsWithNumberRegex.findFirstIn(rawQualifier)
+          versionNumber <- Try(versionNumberQualifierStr.toInt)
+            .toRight(new Exception(s"Version number not parseable to a number. Version number received: $versionNumberQualifierStr"))
+            .toOption
+          newVersionNumber = versionNumber + 1
+          newQualifier = rawQualifier.replaceFirst(versionNumberQualifierStr, newVersionNumber.toString)
+        } yield Version(major, subversions, Some(newQualifier))
+
+        opt.getOrElse(copy(qualifier = None))
+    }
+    def maybeBumpedLastSubversion = bumpSubversionOpt(subversions.length-1)
+    def bumpedMajor = copy(major = major + 1)
+
+    maybeBumpedPrerelease
+      .orElse(maybeBumpedLastSubversion)
+      .getOrElse(bumpedMajor)
+  }
+
   def bumpMajor  = copy(major = major + 1, subversions = Seq.fill(subversions.length)(0))
   def bumpMinor  = maybeBumpSubversion(0)
   def bumpBugfix = maybeBumpSubversion(1)
@@ -65,7 +114,19 @@ case class Version(major: Int, subversions: Seq[Int], qualifier: Option[String])
   def bump(bumpType: Version.Bump): Version = bumpType.bump(this)
 
   def withoutQualifier = copy(qualifier = None)
-  def asSnapshot = copy(qualifier = Some("-SNAPSHOT"))
+  def asSnapshot = copy(qualifier = qualifier.map { qualifierStr =>
+    s"$qualifierStr-SNAPSHOT"
+  }.orElse(Some("-SNAPSHOT")))
+
+  def withoutSnapshot: Version = copy(qualifier = qualifier.flatMap { qualifierStr =>
+    val snapshotRegex = """-SNAPSHOT""".r
+    val newQualifier = snapshotRegex.replaceFirstIn(qualifierStr, "")
+    if (newQualifier == qualifierStr) {
+      None
+    } else {
+      Some(newQualifier)
+    }
+  })
 
   def string = "" + major + mkString(subversions) + qualifier.getOrElse("")
 

--- a/src/main/scala/Version.scala
+++ b/src/main/scala/Version.scala
@@ -13,19 +13,19 @@ object Version {
     /**
      * Strategy to always bump the major version by default. Ex. 1.0.0 would be bumped to 2.0.0
      */
-    case object Major extends Bump { def bump = _.bumpMajor }
+    case object Major extends Bump { def bump: Version => Version = _.bumpMajor }
     /**
      * Strategy to always bump the minor version by default. Ex. 1.0.0 would be bumped to 1.1.0
      */
-    case object Minor extends Bump { def bump = _.bumpMinor }
+    case object Minor extends Bump { def bump: Version => Version = _.bumpMinor }
     /**
      * Strategy to always bump the bugfix version by default. Ex. 1.0.0 would be bumped to 1.0.1
      */
-    case object Bugfix extends Bump { def bump = _.bumpBugfix }
+    case object Bugfix extends Bump { def bump: Version => Version = _.bumpBugfix }
     /**
      * Strategy to always bump the nano version by default. Ex. 1.0.0.0 would be bumped to 1.0.0.1
      */
-    case object Nano extends Bump { def bump = _.bumpNano }
+    case object Nano extends Bump { def bump: Version => Version = _.bumpNano }
     /**
      * Strategy to always increment to the next version from smallest to greatest. This strategy is the default.
      * Ex:
@@ -36,13 +36,13 @@ object Version {
      * Qualifier with version number: 1.0-RC1 becomes 1.0-RC2
      * Qualifier without version number: 1.0-alpha becomes 1.0
      */
-    case object Next extends Bump { def bump = _.bump }
+    case object Next extends Bump { def bump: Version => Version = _.bump }
 
     val default: Bump = Next
   }
 
   val VersionR: Regex = """([0-9]+)((?:\.[0-9]+)+)?([\.\-0-9a-zA-Z]*)?""".r
-  private val PreReleaseQualifierR = """[\.-](?i:rc|m|alpha|beta)[\.-]?[0-9]*""".r
+  val PreReleaseQualifierR: Regex = """[\.-](?i:rc|m|alpha|beta)[\.-]?[0-9]*""".r
 
   def apply(s: String): Option[Version] = {
     allCatch opt {
@@ -88,7 +88,7 @@ case class Version(major: Int, subversions: Seq[Int], qualifier: Option[String])
   def bumpNano: Version = maybeBumpSubversion(2)
   def maybeBumpSubversion(idx: Int): Version = bumpSubversionOpt(idx) getOrElse this
 
-  private def bumpSubversionOpt(idx: Int) = {
+  private def bumpSubversionOpt(idx: Int): Option[Version] = {
     val bumped = subversions.drop(idx)
     val reset = bumped.drop(1).length
     bumped.headOption map { head =>

--- a/src/main/scala/package.scala
+++ b/src/main/scala/package.scala
@@ -2,4 +2,6 @@ package object sbtrelease {
   type Versions = (String, String)
 
   def versionFormatError(version: String) = sys.error(s"Version [$version] format is not compatible with " + Version.VersionR.pattern.toString)
+
+  def expectedSnapshotVersionError(version: String) = sys.error(s"Expected snapshot version. Received: $version")
 }

--- a/src/sbt-test/sbt-release/with-defaults/build.sbt
+++ b/src/sbt-test/sbt-release/with-defaults/build.sbt
@@ -1,3 +1,4 @@
+import sbt.complete.DefaultParsers._
 import sbtrelease.ReleaseStateTransformations._
 
 releaseVersionFile := file("version.sbt")
@@ -13,3 +14,12 @@ releaseProcess := Seq(
   setNextVersion,
   commitNextVersion
 )
+
+val checkContentsOfVersionSbt = inputKey[Unit]("Check that the contents of version.sbt is as expected")
+val parser = Space ~> StringBasic
+
+checkContentsOfVersionSbt := {
+  val expected = parser.parsed
+  val versionFile = ((baseDirectory).value) / "version.sbt"
+  assert(IO.read(versionFile).contains(expected), s"does not contains ${expected} in ${versionFile}")
+}

--- a/src/sbt-test/sbt-release/with-defaults/test
+++ b/src/sbt-test/sbt-release/with-defaults/test
@@ -1,11 +1,41 @@
-$ exec git init .
+# Test Suite Preparation
+    $ exec git init .
+    > update
+    $ exec git add .
+    $ exec git commit -m init
+    > reload
 
-> update
+# SCENARIO: When no release versions are specified in the release command
+    # TEST: Should fail to release if "with-defaults" is not specified
+        -> release
 
-$ exec git add .
-$ exec git commit -m init
+    # TEST: Should succeed if "with-defaults" is specified
+        > release with-defaults
 
-> reload
+# SCENARIO: When default bumping strategy is used
+    # Test Scenario Preparation
+        > 'release release-version 0.9.9 next-version 1.0.0-RC1-SNAPSHOT'
+        > reload
+        > checkContentsOfVersionSbt 1.0.0-RC1-SNAPSHOT
 
--> release
-> release with-defaults
+    # TEST: Snapshot version should be correctly set
+        > release with-defaults
+        > checkContentsOfVersionSbt 1.0.0-RC2-SNAPSHOT
+
+    # TEST: Release version should be correctly set
+        $ exec git reset --hard HEAD~1
+        > reload
+        > checkContentsOfVersionSbt 1.0.0-RC1
+
+# SCENARIO: When NextStable bumping strategy is used
+    # TEST: Snapshot version should be correctly set
+        $ exec git reset --hard HEAD~1
+        > set releaseVersionBump := sbtrelease.Version.Bump.NextStable
+        > release with-defaults
+        > checkContentsOfVersionSbt 1.0.1-SNAPSHOT
+
+    # TEST: Release version should be correctly set
+        $ exec git reset --hard HEAD~1
+        > reload
+        > checkContentsOfVersionSbt 1.0.0
+

--- a/src/test/scala/VersionSpec.scala
+++ b/src/test/scala/VersionSpec.scala
@@ -9,6 +9,46 @@ object VersionSpec extends Specification {
     case None => sys.error("Can't parse version " + v)
   }
 
+  "Version bumping with Qualifier" should {
+    def bump(v: String) = version(v).bumpWithQualifier.string
+
+    "bump the major version if there's only a major version" in {
+      bump("1") must_== "2"
+    }
+    "bump the minor version if there's only a minor version" in {
+      bump("1.2") must_== "1.3"
+    }
+    "bump the bugfix version if there's only a bugfix version" in {
+      bump("1.2.3") must_== "1.2.4"
+    }
+    "bump the nano version if there's only a nano version" in {
+      bump("1.2.3.4") must_== "1.2.3.5"
+    }
+    "drop the qualifier if it's a pre release and there is no version number at the end" in {
+      bump("1-rc") must_== "1"
+      bump("1-beta") must_== "1"
+      bump("1-alpha") must_== "1"
+    }
+    "bump the qualifier if it's a pre release and there is a version number at the end" in {
+      bump("1-rc1") must_== "1-rc2"
+      bump("1.2-rc1") must_== "1.2-rc2"
+      bump("1.2.3-rc1") must_== "1.2.3-rc2"
+
+      bump("1-RC1") must_== "1-RC2"
+      bump("1-M1") must_== "1-M2"
+      bump("1-rc-1") must_== "1-rc-2"
+      bump("1-rc.1") must_== "1-rc.2"
+      bump("1-beta-1") must_== "1-beta-2"
+      bump("1-beta.1") must_== "1-beta.2"
+    }
+    "not drop the qualifier if it's not a pre release" in {
+      bump("1.2.3-Final") must_== "1.2.4-Final"
+    }
+    "not drop the post-nano qualifier if it's not a pre release" in {
+      bump("1.2.3.4-Final") must_== "1.2.3.5-Final"
+    }
+  }
+
   "Version bumping" should {
     def bump(v: String) = version(v).bump.string
 
@@ -92,4 +132,13 @@ object VersionSpec extends Specification {
     }
   }
 
+  "Version as snapshot" should {
+    def snapshot(v: String) = version(v).asSnapshot.string
+    "include qualifier if it exists" in {
+      snapshot("1.0.0-RC1") must_== "1.0.0-RC1-SNAPSHOT"
+    }
+    "have no qualifier if none exists" in {
+      snapshot("1.0.0") must_== "1.0.0-SNAPSHOT"
+    }
+  }
 }

--- a/src/test/scala/VersionSpec.scala
+++ b/src/test/scala/VersionSpec.scala
@@ -1,5 +1,6 @@
 package sbtrelease
 
+import org.specs2.matcher.MatchResult
 import org.specs2.mutable.Specification
 
 object VersionSpec extends Specification {
@@ -8,48 +9,82 @@ object VersionSpec extends Specification {
     case Some(parsed) => parsed
     case None => sys.error("Can't parse version " + v)
   }
-  "Version bumping" should {
-    def bump(v: String) = version(v).bump.string
+  "Next Version bumping" should {
+    def testBumpNext(input: String, expectedOutput: String): MatchResult[Any] = version(input).bumpNext.unapply must_== expectedOutput
+
+    def testBumpNextStable(input: String, expectedOutput: String): MatchResult[Any] = version(input).bumpNextStable.unapply must_== expectedOutput
+
+    def testBothBumpNextStrategies(input: String, expectedOutput: String): MatchResult[Any] = {
+      testBumpNext(input, expectedOutput)
+      testBumpNextStable(input, expectedOutput)
+    }
 
     "bump the major version if there's only a major version" in {
-      bump("1") must_== "2"
+      testBothBumpNextStrategies("1", "2")
     }
     "bump the minor version if there's only a minor version" in {
-      bump("1.2") must_== "1.3"
+      testBothBumpNextStrategies("1.2", "1.3")
     }
     "bump the bugfix version if there's only a bugfix version" in {
-      bump("1.2.3") must_== "1.2.4"
+      testBothBumpNextStrategies("1.2.3", "1.2.4")
     }
     "bump the nano version if there's only a nano version" in {
-      bump("1.2.3.4") must_== "1.2.3.5"
+      testBothBumpNextStrategies("1.2.3.4", "1.2.3.5")
     }
     "drop the qualifier if it's a pre release and there is no version number at the end" in {
-      bump("1-rc") must_== "1"
-      bump("1-beta") must_== "1"
-      bump("1-alpha") must_== "1"
+      testBothBumpNextStrategies("1-rc", "1")
+      testBothBumpNextStrategies("1.0-rc", "1.0")
+      testBothBumpNextStrategies("1.0.0-rc", "1.0.0")
+      testBothBumpNextStrategies("1.0.0.0-rc", "1.0.0.0")
+      testBothBumpNextStrategies("1-beta", "1")
+      testBothBumpNextStrategies("1-alpha", "1")
     }
-    "bump the qualifier if it's a pre release and there is a version number at the end" in {
-      bump("1-rc1") must_== "1-rc2"
-      bump("1.2-rc1") must_== "1.2-rc2"
-      bump("1.2.3-rc1") must_== "1.2.3-rc2"
-
-      bump("1-RC1") must_== "1-RC2"
-      bump("1-M1") must_== "1-M2"
-      bump("1-rc-1") must_== "1-rc-2"
-      bump("1-rc.1") must_== "1-rc.2"
-      bump("1-beta-1") must_== "1-beta-2"
-      bump("1-beta.1") must_== "1-beta.2"
+    "when the qualifier includes a pre release with a version number at the end" >> {
+      "and Next is the bumping strategy" >> {
+        "should bump the qualifier" in {
+          testBumpNext("1-rc1", "1-rc2")
+          testBumpNext("1.2-rc1", "1.2-rc2")
+          testBumpNext("1.2.3-rc1", "1.2.3-rc2")
+          testBumpNext("1-RC1", "1-RC2")
+          testBumpNext("1-M1", "1-M2")
+          testBumpNext("1-rc-1", "1-rc-2")
+          testBumpNext("1-rc.1", "1-rc.2")
+          testBumpNext("1-beta-1", "1-beta-2")
+          testBumpNext("1-beta.1", "1-beta.2")
+        }
+      }
+      "and NextStable is the bumping strategy" >> {
+        "should remove the qualifier" in {
+          testBumpNextStable("1-rc1", "1")
+          testBumpNextStable("1.2-rc1", "1.2")
+          testBumpNextStable("1.2.3-rc1", "1.2.3")
+          testBumpNextStable("1-RC1", "1")
+          testBumpNextStable("1-M1", "1")
+          testBumpNextStable("1-rc-1", "1")
+          testBumpNextStable("1-rc.1", "1")
+          testBumpNextStable("1-beta-1", "1")
+          testBumpNextStable("1-beta.1", "1")
+        }
+      }
     }
-    "not drop the qualifier if it's not a pre release" in {
-      bump("1.2.3-Final") must_== "1.2.4-Final"
-    }
-    "not drop the post-nano qualifier if it's not a pre release" in {
-      bump("1.2.3.4-Final") must_== "1.2.3.5-Final"
+    "never drop the qualifier if it's a final release" >> {
+      "when release is major" in {
+        testBothBumpNextStrategies("1-Final", "2-Final")
+      }
+      "when release is minor" in {
+        testBothBumpNextStrategies("1.2-Final", "1.3-Final")
+      }
+      "when release is subversion" in {
+        testBothBumpNextStrategies("1.2.3-Final", "1.2.4-Final")
+      }
+      "when release is nano" in {
+        testBothBumpNextStrategies("1.2.3.4-Final", "1.2.3.5-Final")
+      }
     }
   }
 
   "Major Version bumping" should {
-    def bumpMajor(v: String) = version(v).bumpMajor.string
+    def bumpMajor(v: String) = version(v).bumpMajor.unapply
 
     "bump the major version and reset other versions" in {
       bumpMajor("1.2.3.4.5") must_== "2.0.0.0.0"
@@ -60,7 +95,7 @@ object VersionSpec extends Specification {
   }
 
   "Minor Version bumping" should {
-    def bumpMinor(v: String) = version(v).bumpMinor.string
+    def bumpMinor(v: String) = version(v).bumpMinor.unapply
 
     "bump the minor version" in {
       bumpMinor("1.2") must_== "1.3"
@@ -77,7 +112,7 @@ object VersionSpec extends Specification {
   }
 
   "Subversion bumping" should {
-    def bumpSubversion(v: String)(i: Int) = version(v).maybeBumpSubversion(i).string
+    def bumpSubversion(v: String)(i: Int) = version(v).maybeBumpSubversion(i).unapply
 
     "bump the subversion" in {
       bumpSubversion("1.2")(0) must_== "1.3"
@@ -104,7 +139,7 @@ object VersionSpec extends Specification {
     }
   }
   "#asSnapshot" should {
-    def snapshot(v: String) = version(v).asSnapshot.string
+    def snapshot(v: String) = version(v).asSnapshot.unapply
     "include qualifier if it exists" in {
       snapshot("1.0.0-RC1") must_== "1.0.0-RC1-SNAPSHOT"
     }
@@ -114,10 +149,10 @@ object VersionSpec extends Specification {
   }
   "#withoutSnapshot" should {
     "remove the snapshot normally" in {
-      version("1.0.0-SNAPSHOT").withoutSnapshot.string must_== "1.0.0"
+      version("1.0.0-SNAPSHOT").withoutSnapshot.unapply must_== "1.0.0"
     }
     "remove the snapshot without removing the qualifier" in {
-      version("1.0.0-RC1-SNAPSHOT").withoutSnapshot.string must_== "1.0.0-RC1"
+      version("1.0.0-RC1-SNAPSHOT").withoutSnapshot.unapply must_== "1.0.0-RC1"
     }
   }
 }

--- a/src/test/scala/VersionSpec.scala
+++ b/src/test/scala/VersionSpec.scala
@@ -9,46 +9,6 @@ object VersionSpec extends Specification {
     case None => sys.error("Can't parse version " + v)
   }
 
-  "Version bumping with Qualifier" should {
-    def bump(v: String) = version(v).bumpWithQualifier.string
-
-    "bump the major version if there's only a major version" in {
-      bump("1") must_== "2"
-    }
-    "bump the minor version if there's only a minor version" in {
-      bump("1.2") must_== "1.3"
-    }
-    "bump the bugfix version if there's only a bugfix version" in {
-      bump("1.2.3") must_== "1.2.4"
-    }
-    "bump the nano version if there's only a nano version" in {
-      bump("1.2.3.4") must_== "1.2.3.5"
-    }
-    "drop the qualifier if it's a pre release and there is no version number at the end" in {
-      bump("1-rc") must_== "1"
-      bump("1-beta") must_== "1"
-      bump("1-alpha") must_== "1"
-    }
-    "bump the qualifier if it's a pre release and there is a version number at the end" in {
-      bump("1-rc1") must_== "1-rc2"
-      bump("1.2-rc1") must_== "1.2-rc2"
-      bump("1.2.3-rc1") must_== "1.2.3-rc2"
-
-      bump("1-RC1") must_== "1-RC2"
-      bump("1-M1") must_== "1-M2"
-      bump("1-rc-1") must_== "1-rc-2"
-      bump("1-rc.1") must_== "1-rc.2"
-      bump("1-beta-1") must_== "1-beta-2"
-      bump("1-beta.1") must_== "1-beta.2"
-    }
-    "not drop the qualifier if it's not a pre release" in {
-      bump("1.2.3-Final") must_== "1.2.4-Final"
-    }
-    "not drop the post-nano qualifier if it's not a pre release" in {
-      bump("1.2.3.4-Final") must_== "1.2.3.5-Final"
-    }
-  }
-
   "Version bumping" should {
     def bump(v: String) = version(v).bump.string
 
@@ -132,13 +92,4 @@ object VersionSpec extends Specification {
     }
   }
 
-  "Version as snapshot" should {
-    def snapshot(v: String) = version(v).asSnapshot.string
-    "include qualifier if it exists" in {
-      snapshot("1.0.0-RC1") must_== "1.0.0-RC1-SNAPSHOT"
-    }
-    "have no qualifier if none exists" in {
-      snapshot("1.0.0") must_== "1.0.0-SNAPSHOT"
-    }
-  }
 }

--- a/src/test/scala/VersionSpec.scala
+++ b/src/test/scala/VersionSpec.scala
@@ -8,9 +8,8 @@ object VersionSpec extends Specification {
     case Some(parsed) => parsed
     case None => sys.error("Can't parse version " + v)
   }
-
-  "Version bumping with Qualifier" should {
-    def bump(v: String) = version(v).bumpWithQualifier.string
+  "Version bumping" should {
+    def bump(v: String) = version(v).bump.string
 
     "bump the major version if there's only a major version" in {
       bump("1") must_== "2"
@@ -40,44 +39,6 @@ object VersionSpec extends Specification {
       bump("1-rc.1") must_== "1-rc.2"
       bump("1-beta-1") must_== "1-beta-2"
       bump("1-beta.1") must_== "1-beta.2"
-    }
-    "not drop the qualifier if it's not a pre release" in {
-      bump("1.2.3-Final") must_== "1.2.4-Final"
-    }
-    "not drop the post-nano qualifier if it's not a pre release" in {
-      bump("1.2.3.4-Final") must_== "1.2.3.5-Final"
-    }
-  }
-
-  "Version bumping" should {
-    def bump(v: String) = version(v).bump.string
-
-    "bump the major version if there's only a major version" in {
-      bump("1") must_== "2"
-    }
-    "bump the minor version if there's only a minor version" in {
-      bump("1.2") must_== "1.3"
-    }
-    "bump the bugfix version if there's only a bugfix version" in {
-      bump("1.2.3") must_== "1.2.4"
-    }
-    "bump the nano version if there's only a nano version" in {
-      bump("1.2.3.4") must_== "1.2.3.5"
-    }
-    "drop the qualifier if it's a pre release" in {
-      bump("1-rc1") must_== "1"
-      bump("1.2-rc1") must_== "1.2"
-      bump("1.2.3-rc1") must_== "1.2.3"
-
-      bump("1-rc") must_== "1"
-      bump("1-RC1") must_== "1"
-      bump("1-M1") must_== "1"
-      bump("1-rc-1") must_== "1"
-      bump("1-rc.1") must_== "1"
-      bump("1-beta") must_== "1"
-      bump("1-beta-1") must_== "1"
-      bump("1-beta.1") must_== "1"
-      bump("1-alpha") must_== "1"
     }
     "not drop the qualifier if it's not a pre release" in {
       bump("1.2.3-Final") must_== "1.2.4-Final"
@@ -131,14 +92,32 @@ object VersionSpec extends Specification {
       bumpSubversion("1.2.3.4.5-alpha")(2) must_== "1.2.3.5.0-alpha"
     }
   }
-
-  "Version as snapshot" should {
+  "#isSnapshot" should {
+    "return true when -SNAPSHOT is appended with another qualifier" in {
+      version("1.0.0-RC1-SNAPSHOT").isSnapshot must_== true
+    }
+    "return false when -SNAPSHOT is not appended but another qualifier exists" in {
+      version("1.0.0-RC1").isSnapshot must_== false
+    }
+    "return false when neither -SNAPSHOT nor qualifier are appended" in {
+      version("1.0.0").isSnapshot must_== false
+    }
+  }
+  "#asSnapshot" should {
     def snapshot(v: String) = version(v).asSnapshot.string
     "include qualifier if it exists" in {
       snapshot("1.0.0-RC1") must_== "1.0.0-RC1-SNAPSHOT"
     }
     "have no qualifier if none exists" in {
       snapshot("1.0.0") must_== "1.0.0-SNAPSHOT"
+    }
+  }
+  "#withoutSnapshot" should {
+    "remove the snapshot normally" in {
+      version("1.0.0-SNAPSHOT").withoutSnapshot.string must_== "1.0.0"
+    }
+    "remove the snapshot without removing the qualifier" in {
+      version("1.0.0-RC1-SNAPSHOT").withoutSnapshot.string must_== "1.0.0-RC1"
     }
   }
 }

--- a/src/test/scala/VersionSpec.scala
+++ b/src/test/scala/VersionSpec.scala
@@ -9,8 +9,8 @@ object VersionSpec extends Specification {
     case None => sys.error("Can't parse version " + v)
   }
 
-  "Version bumping" should {
-    def bump(v: String) = version(v).bump.string
+  "Version bumping with Qualifier" should {
+    def bump(v: String) = version(v).bumpWithQualifier.string
 
     "bump the major version if there's only a major version" in {
       bump("1") must_== "2"
@@ -40,6 +40,44 @@ object VersionSpec extends Specification {
       bump("1-rc.1") must_== "1-rc.2"
       bump("1-beta-1") must_== "1-beta-2"
       bump("1-beta.1") must_== "1-beta.2"
+    }
+    "not drop the qualifier if it's not a pre release" in {
+      bump("1.2.3-Final") must_== "1.2.4-Final"
+    }
+    "not drop the post-nano qualifier if it's not a pre release" in {
+      bump("1.2.3.4-Final") must_== "1.2.3.5-Final"
+    }
+  }
+
+  "Version bumping" should {
+    def bump(v: String) = version(v).bump.string
+
+    "bump the major version if there's only a major version" in {
+      bump("1") must_== "2"
+    }
+    "bump the minor version if there's only a minor version" in {
+      bump("1.2") must_== "1.3"
+    }
+    "bump the bugfix version if there's only a bugfix version" in {
+      bump("1.2.3") must_== "1.2.4"
+    }
+    "bump the nano version if there's only a nano version" in {
+      bump("1.2.3.4") must_== "1.2.3.5"
+    }
+    "drop the qualifier if it's a pre release" in {
+      bump("1-rc1") must_== "1"
+      bump("1.2-rc1") must_== "1.2"
+      bump("1.2.3-rc1") must_== "1.2.3"
+
+      bump("1-rc") must_== "1"
+      bump("1-RC1") must_== "1"
+      bump("1-M1") must_== "1"
+      bump("1-rc-1") must_== "1"
+      bump("1-rc.1") must_== "1"
+      bump("1-beta") must_== "1"
+      bump("1-beta-1") must_== "1"
+      bump("1-beta.1") must_== "1"
+      bump("1-alpha") must_== "1"
     }
     "not drop the qualifier if it's not a pre release" in {
       bump("1.2.3-Final") must_== "1.2.4-Final"
@@ -93,6 +131,7 @@ object VersionSpec extends Specification {
       bumpSubversion("1.2.3.4.5-alpha")(2) must_== "1.2.3.5.0-alpha"
     }
   }
+
   "Version as snapshot" should {
     def snapshot(v: String) = version(v).asSnapshot.string
     "include qualifier if it exists" in {

--- a/src/test/scala/VersionSpec.scala
+++ b/src/test/scala/VersionSpec.scala
@@ -24,20 +24,22 @@ object VersionSpec extends Specification {
     "bump the nano version if there's only a nano version" in {
       bump("1.2.3.4") must_== "1.2.3.5"
     }
-    "drop the qualifier if it's a pre release" in {
-      bump("1-rc1") must_== "1"
-      bump("1.2-rc1") must_== "1.2"
-      bump("1.2.3-rc1") must_== "1.2.3"
-
+    "drop the qualifier if it's a pre release and there is no version number at the end" in {
       bump("1-rc") must_== "1"
-      bump("1-RC1") must_== "1"
-      bump("1-M1") must_== "1"
-      bump("1-rc-1") must_== "1"
-      bump("1-rc.1") must_== "1"
       bump("1-beta") must_== "1"
-      bump("1-beta-1") must_== "1"
-      bump("1-beta.1") must_== "1"
       bump("1-alpha") must_== "1"
+    }
+    "bump the qualifier if it's a pre release and there is a version number at the end" in {
+      bump("1-rc1") must_== "1-rc2"
+      bump("1.2-rc1") must_== "1.2-rc2"
+      bump("1.2.3-rc1") must_== "1.2.3-rc2"
+
+      bump("1-RC1") must_== "1-RC2"
+      bump("1-M1") must_== "1-M2"
+      bump("1-rc-1") must_== "1-rc-2"
+      bump("1-rc.1") must_== "1-rc.2"
+      bump("1-beta-1") must_== "1-beta-2"
+      bump("1-beta.1") must_== "1-beta.2"
     }
     "not drop the qualifier if it's not a pre release" in {
       bump("1.2.3-Final") must_== "1.2.4-Final"
@@ -91,5 +93,13 @@ object VersionSpec extends Specification {
       bumpSubversion("1.2.3.4.5-alpha")(2) must_== "1.2.3.5.0-alpha"
     }
   }
-
+  "Version as snapshot" should {
+    def snapshot(v: String) = version(v).asSnapshot.string
+    "include qualifier if it exists" in {
+      snapshot("1.0.0-RC1") must_== "1.0.0-RC1-SNAPSHOT"
+    }
+    "have no qualifier if none exists" in {
+      snapshot("1.0.0") must_== "1.0.0-SNAPSHOT"
+    }
+  }
 }


### PR DESCRIPTION
## Background Summary
This PR adds support for incrementing prerelease versions by default, if it ends in a number. Currently, if a prerelease version is incremented, the prerelease qualifier is simply dropped. E.g. `1.0.0-RC1` will be incremented to `1.0.0`. After this merge, `1.0.0-RC1` will be incremented to `1.0.0-RC2`, but prerelease versions without a version number will behave as before: `1.0.0-alpha` will be incremented to `1.0.0`.

### New/Updated Versioning Strategies
`Next` (**updated - breaking change**):   Will now increment prerelease versions, unlike in the past. So `1.0-RC1` will become `1.0-RC2`. Previously `1.0-RC1` would become `1.1`.

`NextStable` (**new**): The same as `Next` except that it excludes any prerelease versions. So `1.0.0-RC1` becomes `1.0.0`

### New/Updated Methods in Version class
`.asSnapshot`  (**updated - breaking change**) will now include the prerelease version. E.g. `1.0.0-RC1` will return `1.0.0-RC1-SNAPSHOT`. Previously, `1.0.0-RC1` would become `1.0.0-SNAPSHOT`.
`.withoutSnapshot` (**new**) will remove only the snapshot part of the ending. E.g. `1.0.0-RC1-SNAPSHOT` will become `1.0.0-RC1`. 

`.bumpNext` (**new**) will bump the version according to the `Next` strategy.
`.bumpNextStable` (**new**) will bump the version according to the `NextStable` strategy.
`.bump` (**deprecated**) will now point to `.bumpNext`

### Miscellaneous Changes

Removed emitted warnings and updated deprecated `processResult` method to `processResult2`.

Deprecated `.string` on the Version class and created a new method `.unapply` with the same functionality. `.string` is too similar to `.toString` (just in this simple PR, I created an annoying bug by accidentally typing `.toString` when I meant to type `.string`) and it doesn't follow the standard apply/unapply pattern. Since the Version case class already has a custom `.apply` method with a string input, it ought to have an `.unapply` method with a string output.

Updated README to reflect that certain keys are now task keys and not setting keys. This is just a documentation change - the underlying functionality was changed some time ago in https://github.com/sbt/sbt-release/pull/194, but the README was never updated.

### Feature History

A previous PR to implement this feature was merged and then reverted without comment here: https://github.com/sbt/sbt-release/pull/393. 

Changes introduced by the reviewer created a bug in https://github.com/sbt/sbt-release/pull/393. This was fixed in https://github.com/sbt/sbt-release/pull/395, but closed with no relevant comment - all changes there were necessary. 

Use case - we are planning to release a number of prerelease versions before an initial rollout and these few changes would make that a lot easier.

Many thanks in advance for a review!