### PR TITLE
Avoid deprecated `scala.App`

### DIFF
--- a/src/sbt-test/sbt-release/command-line-version-numbers/src/main/scala/Hello.scala
+++ b/src/sbt-test/sbt-release/command-line-version-numbers/src/main/scala/Hello.scala
@@ -1,3 +1,5 @@
-object Main extends App {
-  println("hello")
+object Main {
+  def main(args: Array[String]): Unit = {
+    println("hello")
+  }
 }


### PR DESCRIPTION
https://github.com/scala/scala3/blob/3.8.4/library/src/scala/App.scala#L65